### PR TITLE
Add documentation of resource attributes

### DIFF
--- a/lib/application.json
+++ b/lib/application.json
@@ -1,5 +1,8 @@
 {
   "id": "aa546741-b54a-403c-a67a-7f5aec1939d1",
+  "status": "open",
+  "status_ucas_code": "C",
+  "personal_statement": "Since retiring from the Police Service in 2007...",
   "candidate": {
     "id": "a0afe017-ea18-491d-9bda-16037102e1dd",
     "email": "boris.brown@racingdemon.net",
@@ -45,17 +48,18 @@
     "job_title": "Whole School Literacy Specialist",
     "job_description": "I lead, develop and enhance the literacy teaching practice of others..."
   }],
-  "status": "open",
-  "status_ucas_code": "C",
-  "personal_statement": "Since retiring from the Police Service in 2007...",
-  "withdrawal": {
-    "reason": "Candidate is unwell",
-    "date": "2019-01-30"
+  "interviews": [{
+    "booked_at": "2019-01-16T14:00:00Z",
+    "date": "2019-01-18T10:30:00Z",
+    "instructions": "Come to Room 4 in Building 6",
+    "address": "Acorns Teaching School Alliance HQ, 1 Romney Way, Doncaster, DN1 8TQ"
   },
-  "rejection": {
-    "reason": "Does not meet minimum GCSE requirements",
-    "date": "2019-01-30"
-  },
+  {
+    "booked_at": "2019-01-19T09:00:00Z",
+    "date": "2019-01-21T10:30:00Z",
+    "instructions": "Come to Room 4 in Building 6",
+    "address": "Acorns Teaching School Alliance HQ, 1 Romney Way, Doncaster, DN1 8TQ"
+  }],
   "offer": {
     "course": {
       "description": "Acorns Teaching School Alliance, Primary (salaried, full-time)",
@@ -69,18 +73,14 @@
       "Completion of professional skills test"
     ]
   },
-  "interviews": [{
-    "booked_at": "2019-01-16T14:00:00Z",
-    "date": "2019-01-18T10:30:00Z",
-    "instructions": "Come to Room 4 in Building 6",
-    "address": "Acorns Teaching School Alliance HQ, 1 Romney Way, Doncaster, DN1 8TQ"
+  "withdrawal": {
+    "reason": "Candidate is unwell",
+    "date": "2019-01-30"
   },
-  {
-    "booked_at": "2019-01-19T09:00:00Z",
-    "date": "2019-01-21T10:30:00Z",
-    "instructions": "Come to Room 4 in Building 6",
-    "address": "Acorns Teaching School Alliance HQ, 1 Romney Way, Doncaster, DN1 8TQ"
-  }],
+  "rejection": {
+    "reason": "Does not meet minimum GCSE requirements",
+    "date": "2019-01-30"
+  },
   "created_at": "2019-06-13T10:44:31Z",
   "updated_at": "2019-06-13T10:44:31Z"
 }

--- a/lib/application_json.rb
+++ b/lib/application_json.rb
@@ -1,9 +1,19 @@
 module ApplicationJson
+  DUMMY_OBJECT = '{ ... }'.freeze
+  DUMMY_ARRAY_OF_OBJECTS = '[ { ... } ]'.freeze
+
   def single_application_json
     JSON.pretty_generate(
       json_data.merge(
         'withdrawal' => nil,
-        'rejection' => nil
+        'rejection' => nil,
+        'offer' => nil,
+        'candidate' => DUMMY_OBJECT,
+        'contact_details' => DUMMY_OBJECT,
+        'course' => DUMMY_ARRAY_OF_OBJECTS,
+        'work_experiences' => DUMMY_ARRAY_OF_OBJECTS,
+        'qualifications' => DUMMY_ARRAY_OF_OBJECTS,
+        'interviews' => DUMMY_ARRAY_OF_OBJECTS
       )
     )
   end

--- a/lib/application_json.rb
+++ b/lib/application_json.rb
@@ -2,8 +2,8 @@ module ApplicationJson
   def single_application_json
     JSON.pretty_generate(
       json_data.merge(
-        "withdrawal": nil,
-        "rejection": nil
+        'withdrawal' => nil,
+        'rejection' => nil
       )
     )
   end

--- a/lib/application_json.rb
+++ b/lib/application_json.rb
@@ -18,6 +18,21 @@ module ApplicationJson
     )
   end
 
+  def application_attributes
+    [
+      {
+        name: 'id',
+        type: 'uuid',
+        description: 'The unique ID of this application'
+      },
+      {
+        name: 'created_at',
+        type: 'string',
+        description: 'ISO8601 date with time'
+      }
+    ]
+  end
+
   def json_data
     @json_data ||= JSON.parse(File.read('lib/application.json'))
   end

--- a/source/partials/_attribute_table.html.erb
+++ b/source/partials/_attribute_table.html.erb
@@ -1,0 +1,13 @@
+<table>
+  <% attributes.each do |attribute| %>
+    <tr>
+      <td>
+        <%= attribute[:name] %>
+      </td>
+      <td>
+        <strong><%= attribute[:type] %></strong>
+      </td>
+      <td><%= attribute[:description] %></td>
+    </tr>
+  <% end %>
+</table>

--- a/source/resources_and_their_attributes.html.md.erb
+++ b/source/resources_and_their_attributes.html.md.erb
@@ -1,0 +1,28 @@
+---
+title: Resources and their attributes
+weight: 70
+---
+
+# Resources and their attributes
+
+## Application
+
+<%= partial 'partials/attribute_table', locals: { attributes: application_attributes } %>
+
+## Candidate
+
+## Contact details
+
+## Course
+
+## Qualification
+
+## Work experience
+
+## Interview
+
+## Offer
+
+## Withdrawal
+
+## Rejection

--- a/source/retrieve_a_single_application.html.md.erb
+++ b/source/retrieve_a_single_application.html.md.erb
@@ -23,4 +23,17 @@ GET /applications/aa546741-b54a-403c-a67a-7f5aec1939d1
 
 ## Attributes
 
-@todo
+<%= partial 'partials/attribute_table', locals: {
+  attributes: [
+    {
+      name: 'id',
+      type: 'uuid',
+      description: 'The unique ID of this application'
+    },
+    {
+      name: 'created_at',
+      type: 'string',
+      description: 'ISO8601 date with time'
+    }
+  ]
+} %>

--- a/source/retrieve_a_single_application.html.md.erb
+++ b/source/retrieve_a_single_application.html.md.erb
@@ -23,17 +23,4 @@ GET /applications/aa546741-b54a-403c-a67a-7f5aec1939d1
 
 ## Attributes
 
-<%= partial 'partials/attribute_table', locals: {
-  attributes: [
-    {
-      name: 'id',
-      type: 'uuid',
-      description: 'The unique ID of this application'
-    },
-    {
-      name: 'created_at',
-      type: 'string',
-      description: 'ISO8601 date with time'
-    }
-  ]
-} %>
+<%= partial 'partials/attribute_table', locals: { attributes: application_attributes } %>

--- a/spec/application_json_spec.rb
+++ b/spec/application_json_spec.rb
@@ -14,6 +14,11 @@ RSpec.describe ApplicationJson do
     withdrawal rejection offer interviews created_at updated_at
   ].freeze
 
+  APPLICATION_SUBRESOURCES = %w[
+    candidate contact_details course qualifications
+    work_experiences withdrawal rejection offer interviews
+  ]
+
   describe '.single_application_json' do
     subject(:parsed_json) do
       JSON.parse(including_class.single_application_json)
@@ -24,14 +29,18 @@ RSpec.describe ApplicationJson do
       expect(parsed_json.keys).to match_array(ALL_APPLICATION_FIELDS)
     end
 
-    it 'has two interviews and an offer' do
-      expect(parsed_json['interviews'].count).to eq 2
-      expect(parsed_json['offer']).not_to be_nil
-    end
-
     it 'does not have a withdrawal or rejection' do
       expect(parsed_json['withdrawal']).to be_nil
       expect(parsed_json['rejection']).to be_nil
+    end
+
+    it 'does not include subresources' do
+      expect(parsed_json.values_at(*APPLICATION_SUBRESOURCES))
+        .to all(satisfy do |v|
+          v.nil? ||
+          v == ApplicationJson::DUMMY_OBJECT ||
+          v == ApplicationJson::DUMMY_ARRAY_OF_OBJECTS
+      end)
     end
   end
 end


### PR DESCRIPTION
Enable attribute lists to be displayed alongside resources using a partial, which can also be included on the dedicated "Resources and their attributes" page