### PR TITLE
Establish a convention for referring to complex data types in attributes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,3 +15,5 @@ gem "rspec", "~> 3.8"
 
 gem "rubocop", "~> 0.71.0"
 gem "rubocop-rspec", "~> 1.33"
+
+gem "capybara", "~> 3.24"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,6 +12,14 @@ GEM
     autoprefixer-rails (6.7.7.2)
       execjs
     backports (3.14.0)
+    capybara (3.24.0)
+      addressable
+      mini_mime (>= 0.1.3)
+      nokogiri (~> 1.8)
+      rack (>= 1.6.0)
+      rack-test (>= 0.6.3)
+      regexp_parser (~> 1.5)
+      xpath (~> 3.2)
     chronic (0.10.2)
     chunky_png (1.3.11)
     coderay (1.1.2)
@@ -127,6 +135,7 @@ GEM
     middleman-syntax (3.0.0)
       middleman-core (>= 3.2)
       rouge (~> 2.0)
+    mini_mime (1.0.1)
     mini_portile2 (2.4.0)
     minitest (5.11.3)
     multi_json (1.13.1)
@@ -150,12 +159,15 @@ GEM
     rack (2.0.7)
     rack-livereload (0.3.17)
       rack
+    rack-test (1.1.0)
+      rack (>= 1.0, < 3)
     rainbow (3.0.0)
     rake (12.3.2)
     rb-fsevent (0.10.3)
     rb-inotify (0.10.0)
       ffi (~> 1.0)
     redcarpet (3.3.4)
+    regexp_parser (1.5.1)
     rouge (2.2.1)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)
@@ -199,11 +211,14 @@ GEM
     uglifier (3.2.0)
       execjs (>= 0.3.0, < 3)
     unicode-display_width (1.6.0)
+    xpath (3.2.0)
+      nokogiri (~> 1.8)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  capybara (~> 3.24)
   govuk_tech_docs
   rspec (~> 3.8)
   rubocop (~> 0.71.0)

--- a/config.rb
+++ b/config.rb
@@ -1,6 +1,4 @@
 require 'govuk_tech_docs'
 require 'lib/application_json'
 
-GovukTechDocs.configure(self)
-
 helpers ApplicationJson

--- a/environments/development.rb
+++ b/environments/development.rb
@@ -1,0 +1,1 @@
+GovukTechDocs.configure(self)

--- a/environments/test.rb
+++ b/environments/test.rb
@@ -1,0 +1,1 @@
+GovukTechDocs.configure(self, livereload: nil)

--- a/lib/application_json.rb
+++ b/lib/application_json.rb
@@ -29,6 +29,21 @@ module ApplicationJson
         name: 'created_at',
         type: 'string',
         description: 'ISO8601 date with time'
+      },
+      {
+        name: 'candidate',
+        type: '<a href="/resources_and_their_attributes.html#candidate">Candidate</a>',
+        description: 'Candidate details'
+      }
+    ]
+  end
+
+  def candidate_attributes
+    [
+      {
+        name: 'id',
+        type: 'uuid',
+        description: 'The unique ID of this candidate'
       }
     ]
   end

--- a/lib/application_json.rb
+++ b/lib/application_json.rb
@@ -32,7 +32,7 @@ module ApplicationJson
       },
       {
         name: 'candidate',
-        type: '<a href="/resources_and_their_attributes.html#candidate">Candidate</a>',
+        type: link_to_resource_definition('Candidate'),
         description: 'Candidate details'
       }
     ]
@@ -46,6 +46,13 @@ module ApplicationJson
         description: 'The unique ID of this candidate'
       }
     ]
+  end
+
+  def link_to_resource_definition(resource_name)
+    slug = resource_name.downcase.gsub(' ', '_')
+    "<a href='/resources_and_their_attributes.html##{slug}'>
+      #{resource_name}
+    </a>"
   end
 
   def json_data

--- a/source/resources_and_their_attributes.html.md.erb
+++ b/source/resources_and_their_attributes.html.md.erb
@@ -11,6 +11,8 @@ weight: 70
 
 ## Candidate
 
+<%= partial 'partials/attribute_table', locals: { attributes: candidate_attributes } %>
+
 ## Contact details
 
 ## Course

--- a/spec/features/following_resource_links_spec.rb
+++ b/spec/features/following_resource_links_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+RSpec.describe 'following resource links', type: :feature do
+  scenario 'clicking the "Candidate" link in the "Application" attributes list' do
+    visit '/'
+
+    click_on 'Retrieve a single application'
+    within 'table' do
+      click_on 'Candidate'
+    end
+
+    expect(page).to have_content 'The unique ID of this candidate'
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,6 +13,19 @@
 # it.
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
+
+# https://github.com/SimonRice/middleman-rspec/blob/master/spec/spec_helper.rb
+require 'capybara/rspec'
+require 'middleman-core'
+require 'middleman-core/rack'
+
+middleman_app = ::Middleman::Application.new do
+  set :environment, :test
+  set :show_exceptions, false
+end
+
+Capybara.app = ::Middleman::Rack.new(middleman_app).to_app
+
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest


### PR DESCRIPTION
This PR introduces links between static pages. These might easily break.
To give ourselves confidence we’re adding Capybara to drive an
integration test which should catch regressions.