### PR TITLE
Filling in attributes

### DIFF
--- a/lib/application_json.rb
+++ b/lib/application_json.rb
@@ -273,6 +273,35 @@ module ApplicationJson
     ]
   end
 
+  def interview_json
+    JSON.pretty_generate(json_data['interviews'].first)
+  end
+
+  def interview_attributes
+    [
+      {
+        name: 'booked_at',
+        type: 'string',
+        description: 'The ISO8601 date and time this interview was booked'
+      },
+      {
+        name: 'date',
+        type: 'string',
+        description: 'The ISO8601 date and time this interview takes place'
+      },
+      {
+        name: 'instructions',
+        type: 'string',
+        description: 'Instructions to the candidate'
+      },
+      {
+        name: 'address',
+        type: 'string',
+        description: 'The address of the building where the interview takes place'
+      }
+    ]
+  end
+
   def link_to_resource_definition(resource_name)
     slug = resource_name.downcase.gsub(' ', '_')
     "<a href='/resources-and-their-attributes##{slug}'>

--- a/lib/application_json.rb
+++ b/lib/application_json.rb
@@ -26,14 +26,74 @@ module ApplicationJson
         description: 'The unique ID of this application'
       },
       {
-        name: 'created_at',
+        name: 'status',
         type: 'string',
-        description: 'ISO8601 date with time'
+        description: 'The status of this application'
+      },
+      {
+        name: 'status_ucas_code',
+        type: 'string',
+        description: 'The status of this application in legacy UCAS code format'
+      },
+      {
+        name: 'personal_statement',
+        type: 'string',
+        description: 'The candidate’s personal statement'
+      },
+      {
+        name: 'offer',
+        type: link_to_resource_definition('Offer'),
+        description: 'The offer on this application, if there is one'
+      },
+      {
+        name: 'rejection',
+        type: link_to_resource_definition('Rejection'),
+        description: 'Rejection details, if applicable'
+      },
+      {
+        name: 'withdrawal',
+        type: link_to_resource_definition('Withdrawal'),
+        description: 'Application withdrawal details, if applicable'
       },
       {
         name: 'candidate',
         type: link_to_resource_definition('Candidate'),
         description: 'Candidate details'
+      },
+      {
+        name: 'contact_details',
+        type: link_to_resource_definition('Contact details'),
+        description: 'Contact details'
+      },
+      {
+        name: 'course',
+        type: link_to_resource_definition('Course'),
+        description: 'Contact details'
+      },
+      {
+        name: 'work_experiences',
+        type: link_to_resource_definition('Work experience'),
+        description: 'A list of work experiences'
+      },
+      {
+        name: 'qualifications',
+        type: link_to_resource_definition('Qualification'),
+        description: 'A list of qualifications'
+      },
+      {
+        name: 'interviews',
+        type: link_to_resource_definition('Interview'),
+        description: 'A list of interviews'
+      },
+      {
+        name: 'created_at',
+        type: 'string',
+        description: 'ISO8601 date with time and timezone'
+      },
+      {
+        name: 'updated_at',
+        type: 'string',
+        description: 'ISO8601 date with time and timezone'
       }
     ]
   end

--- a/lib/application_json.rb
+++ b/lib/application_json.rb
@@ -302,6 +302,30 @@ module ApplicationJson
     ]
   end
 
+  def offer_json
+    JSON.pretty_generate(json_data['offer'])
+  end
+
+  def offer_attributes
+    [
+      {
+        name: 'course',
+        type: link_to_resource_definition('Course'),
+        description: ''
+      },
+      {
+        name: 'date',
+        type: 'string',
+        description: 'The offered entry date'
+      },
+      {
+        name: 'conditions',
+        type: 'array of strings',
+        description: 'The conditions of the offer'
+      }
+    ]
+  end
+
   def link_to_resource_definition(resource_name)
     slug = resource_name.downcase.gsub(' ', '_')
     "<a href='/resources-and-their-attributes##{slug}'>

--- a/lib/application_json.rb
+++ b/lib/application_json.rb
@@ -152,6 +152,25 @@ module ApplicationJson
     ]
   end
 
+  def contact_details_json
+    JSON.pretty_generate(json_data['contact_details'])
+  end
+
+  def contact_details_attributes
+    [
+      {
+        name: 'address',
+        type: 'string',
+        description: 'The candidate’s address'
+      },
+      {
+        name: 'phone_number',
+        type: 'string',
+        description: 'The candidate’s phone number'
+      }
+    ]
+  end
+
   def link_to_resource_definition(resource_name)
     slug = resource_name.downcase.gsub(' ', '_')
     "<a href='/resources-and-their-attributes##{slug}'>

--- a/lib/application_json.rb
+++ b/lib/application_json.rb
@@ -365,10 +365,9 @@ module ApplicationJson
   end
 
   def link_to_resource_definition(resource_name)
-    slug = resource_name.downcase.gsub(' ', '_')
-    "<a href='/resources-and-their-attributes##{slug}'>
-      #{resource_name}
-    </a>"
+    slug = resource_name.downcase.gsub(' ', '-')
+    link = "/resources-and-their-attributes##{slug}"
+    "<a href='#{link}'>#{resource_name}</a>"
   end
 
   def json_data

--- a/lib/application_json.rb
+++ b/lib/application_json.rb
@@ -98,12 +98,56 @@ module ApplicationJson
     ]
   end
 
+  def candidate_json
+    JSON.pretty_generate(json_data['candidate'])
+  end
+
   def candidate_attributes
     [
       {
         name: 'id',
         type: 'uuid',
         description: 'The unique ID of this candidate'
+      },
+      {
+        name: 'email',
+        type: 'string',
+        description: 'The candidate’s email address'
+      },
+      {
+        name: 'first_name',
+        type: 'string',
+        description: ''
+      },
+      {
+        name: 'last_name',
+        type: 'string',
+        description: ''
+      },
+      {
+        name: 'date_of_birth',
+        type: 'string',
+        description: 'The candidate’s date of birth in YYYY-MM-DD format'
+      },
+      {
+        name: 'nationality',
+        type: 'string',
+        description: 'The applicant’s nationality'
+      },
+      {
+        name: 'residency_status',
+        type: 'string',
+        description: 'The applicant’s residency_status'
+      },
+      {
+        name: 'disability',
+        type: 'string',
+        description: 'The candidate’s disabilities in a sentence'
+      },
+      {
+        name: 'disability_hesa_code',
+        type: 'string',
+        description: 'The candidate’s disabilities expressed as a HESA code'
       }
     ]
   end

--- a/lib/application_json.rb
+++ b/lib/application_json.rb
@@ -345,6 +345,25 @@ module ApplicationJson
     ]
   end
 
+  def rejection_json
+    JSON.pretty_generate(json_data['rejection'])
+  end
+
+  def rejection_attributes
+    [
+      {
+        name: 'reason',
+        type: 'string',
+        description: 'The reason for rejection'
+      },
+      {
+        name: 'date',
+        type: 'string',
+        description: 'The date on which the rejection was issued in YYYY-MM-DD format'
+      }
+    ]
+  end
+
   def link_to_resource_definition(resource_name)
     slug = resource_name.downcase.gsub(' ', '_')
     "<a href='/resources-and-their-attributes##{slug}'>

--- a/lib/application_json.rb
+++ b/lib/application_json.rb
@@ -316,12 +316,31 @@ module ApplicationJson
       {
         name: 'date',
         type: 'string',
-        description: 'The offered entry date'
+        description: 'The offered entry date in YYYY-MM-DD format'
       },
       {
         name: 'conditions',
         type: 'array of strings',
         description: 'The conditions of the offer'
+      }
+    ]
+  end
+
+  def withdrawal_json
+    JSON.pretty_generate(json_data['withdrawal'])
+  end
+
+  def withdrawal_attributes
+    [
+      {
+        name: 'reason',
+        type: 'string',
+        description: 'The candidate’s reason for withdrawing'
+      },
+      {
+        name: 'date',
+        type: 'string',
+        description: 'The date on which the withdrawal was received in YYYY-MM-DD format'
       }
     ]
   end

--- a/lib/application_json.rb
+++ b/lib/application_json.rb
@@ -200,6 +200,45 @@ module ApplicationJson
     ]
   end
 
+  def qualification_json
+    JSON.pretty_generate(json_data['qualifications'].first)
+  end
+
+  def qualification_attributes
+    [
+      {
+        name: 'type',
+        type: 'string',
+        description: 'The qualification awarded'
+      },
+      {
+        name: 'subject',
+        type: 'string',
+        description: 'The subject studied'
+      },
+      {
+        name: 'grade',
+        type: 'string',
+        description: 'The grade awarded'
+      },
+      {
+        name: 'award_date',
+        type: 'string',
+        description: 'The date awarded, in YYYY-MM-DD format'
+      },
+      {
+        name: 'institution_name',
+        type: 'string',
+        description: 'The awarding institution'
+      },
+      {
+        name: 'international',
+        type: 'boolean',
+        description: 'Was this qualification awarded by a non-UK body'
+      }
+    ]
+  end
+
   def link_to_resource_definition(resource_name)
     slug = resource_name.downcase.gsub(' ', '_')
     "<a href='/resources-and-their-attributes##{slug}'>

--- a/lib/application_json.rb
+++ b/lib/application_json.rb
@@ -239,6 +239,40 @@ module ApplicationJson
     ]
   end
 
+  def work_experience_json
+    JSON.pretty_generate(json_data['work_experiences'].first)
+  end
+
+  def work_experience_attributes
+    [
+      {
+        name: 'employer_name',
+        type: 'string',
+        description: ''
+      },
+      {
+        name: 'start_date',
+        type: 'string',
+        description: 'The date employment began in YYYY-MM-DD format'
+      },
+      {
+        name: 'end_date',
+        type: 'string',
+        description: 'The date employment finished in YYYY-MM-DD format, if appropriate'
+      },
+      {
+        name: 'job_title',
+        type: 'string',
+        description: ''
+      },
+      {
+        name: 'job_description',
+        type: 'string',
+        description: ''
+      }
+    ]
+  end
+
   def link_to_resource_definition(resource_name)
     slug = resource_name.downcase.gsub(' ', '_')
     "<a href='/resources-and-their-attributes##{slug}'>

--- a/lib/application_json.rb
+++ b/lib/application_json.rb
@@ -171,6 +171,35 @@ module ApplicationJson
     ]
   end
 
+  def course_json
+    JSON.pretty_generate(json_data['course'])
+  end
+
+  def course_attributes
+    [
+      {
+        name: 'description',
+        type: 'string',
+        description: 'The plain text description of the course'
+      },
+      {
+        name: 'provider_ucas_code',
+        type: 'string',
+        description: 'The provider’s UCAS code'
+      },
+      {
+        name: 'course_ucas_code',
+        type: 'string',
+        description: 'The course’s UCAS code'
+      },
+      {
+        name: 'location_ucas_code',
+        type: 'string',
+        description: 'The location’s UCAS code'
+      }
+    ]
+  end
+
   def link_to_resource_definition(resource_name)
     slug = resource_name.downcase.gsub(' ', '_')
     "<a href='/resources-and-their-attributes##{slug}'>

--- a/source/resources-and-their-attributes.html.md.erb
+++ b/source/resources-and-their-attributes.html.md.erb
@@ -7,9 +7,17 @@ weight: 70
 
 ## Application
 
+```json
+<%= single_application_json %>
+```
+
 <%= partial 'partials/attribute_table', locals: { attributes: application_attributes } %>
 
 ## Candidate
+
+```json
+<%= candidate_json %>
+```
 
 <%= partial 'partials/attribute_table', locals: { attributes: candidate_attributes } %>
 

--- a/source/resources-and-their-attributes.html.md.erb
+++ b/source/resources-and-their-attributes.html.md.erb
@@ -23,6 +23,12 @@ weight: 70
 
 ## Contact details
 
+```json
+<%= contact_details_json %>
+```
+
+<%= partial 'partials/attribute_table', locals: { attributes: contact_details_attributes } %>
+
 ## Course
 
 ## Qualification

--- a/spec/application_json_spec.rb
+++ b/spec/application_json_spec.rb
@@ -19,7 +19,12 @@ RSpec.describe ApplicationJson do
     work_experiences withdrawal rejection offer interviews
   ]
 
-  describe '.single_application_json' do
+  ALL_CANDIDATE_FIELDS = %w[
+    id email first_name last_name date_of_birth nationality
+    residency_status disability disability_hesa_code
+  ].freeze
+
+  describe '#single_application_json' do
     subject(:parsed_json) do
       JSON.parse(including_class.single_application_json)
     end
@@ -48,6 +53,42 @@ RSpec.describe ApplicationJson do
     it 'contains an entry for all the relevant fields' do
       fields = including_class.application_attributes.map { |desc| desc[:name] }
       expect(fields).to match_array(ALL_APPLICATION_FIELDS)
+    end
+  end
+
+  describe '#candidate_json' do
+    subject(:parsed_json) do
+      JSON.parse(including_class.candidate_json)
+    end
+
+    it 'returns the JSON for a candidate with all the fields present' do
+      expect(parsed_json).to be_a Hash
+      expect(parsed_json.keys).to match_array(ALL_CANDIDATE_FIELDS)
+    end
+  end
+
+  describe '#candidate_attributes' do
+    it 'contains an entry for all the relevant fields' do
+      fields = including_class.candidate_attributes.map { |desc| desc[:name] }
+      expect(fields).to match_array(ALL_CANDIDATE_FIELDS)
+    end
+  end
+
+  describe '#contact_details_json' do
+    subject(:parsed_json) do
+      JSON.parse(including_class.contact_details_json)
+    end
+
+    it 'returns the JSON for a candidate with all the fields present' do
+      expect(parsed_json).to be_a Hash
+      expect(parsed_json.keys).to match_array(ALL_CONTACT_DETAILS_FIELDS)
+    end
+  end
+
+  describe '#candidate_attributes' do
+    it 'contains an entry for all the relevant fields' do
+      fields = including_class.contact_details_json.map { |desc| desc[:name] }
+      expect(fields).to match_array(ALL_CONTACT_DETAILS_FIELDS)
     end
   end
 end

--- a/spec/application_json_spec.rb
+++ b/spec/application_json_spec.rb
@@ -36,6 +36,10 @@ RSpec.describe ApplicationJson do
     type subject grade award_date institution_name international
   ].freeze
 
+  ALL_WORK_EXPERIENCE_FIELDS = %w[
+    employer_name start_date end_date job_title job_description
+  ].freeze
+
   describe '#single_application_json' do
     subject(:parsed_json) do
       JSON.parse(including_class.single_application_json)
@@ -139,6 +143,46 @@ RSpec.describe ApplicationJson do
         desc[:name]
       end
       expect(fields).to match_array(ALL_QUALIFICATION_FIELDS)
+    end
+  end
+
+  describe '#work_experience_json' do
+    subject(:parsed_json) do
+      JSON.parse(including_class.work_experience_json)
+    end
+
+    it 'returns the JSON for a qualification with all the fields present' do
+      expect(parsed_json).to be_a Hash
+      expect(parsed_json.keys).to match_array(ALL_WORK_EXPERIENCE_FIELDS)
+    end
+  end
+
+  describe '#work_experience_attributes' do
+    it 'contains an entry for all the relevant fields' do
+      fields = including_class.work_experience_attributes.map do |desc|
+        desc[:name]
+      end
+      expect(fields).to match_array(ALL_WORK_EXPERIENCE_FIELDS)
+    end
+  end
+
+  describe '#work_experience_json' do
+    subject(:parsed_json) do
+      JSON.parse(including_class.work_experience_json)
+    end
+
+    it 'returns the JSON for a qualification with all the fields present' do
+      expect(parsed_json).to be_a Hash
+      expect(parsed_json.keys).to match_array(ALL_WORK_EXPERIENCE_FIELDS)
+    end
+  end
+
+  describe '#work_experience_attributes' do
+    it 'contains an entry for all the relevant fields' do
+      fields = including_class.work_experience_attributes.map do |desc|
+        desc[:name]
+      end
+      expect(fields).to match_array(ALL_WORK_EXPERIENCE_FIELDS)
     end
   end
 end

--- a/spec/application_json_spec.rb
+++ b/spec/application_json_spec.rb
@@ -28,6 +28,10 @@ RSpec.describe ApplicationJson do
     phone_number address
   ].freeze
 
+  ALL_COURSE_FIELDS = %w[
+    description provider_ucas_code course_ucas_code location_ucas_code
+  ].freeze
+
   describe '#single_application_json' do
     subject(:parsed_json) do
       JSON.parse(including_class.single_application_json)
@@ -93,6 +97,24 @@ RSpec.describe ApplicationJson do
     it 'contains an entry for all the relevant fields' do
       fields = including_class.contact_details_attributes.map { |desc| desc[:name] }
       expect(fields).to match_array(ALL_CONTACT_DETAILS_FIELDS)
+    end
+  end
+
+  describe '#course_json' do
+    subject(:parsed_json) do
+      JSON.parse(including_class.course_json)
+    end
+
+    it 'returns the JSON for a course with all the fields present' do
+      expect(parsed_json).to be_a Hash
+      expect(parsed_json.keys).to match_array(ALL_COURSE_FIELDS)
+    end
+  end
+
+  describe '#course_attributes' do
+    it 'contains an entry for all the relevant fields' do
+      fields = including_class.course_attributes.map { |desc| desc[:name] }
+      expect(fields).to match_array(ALL_COURSE_FIELDS)
     end
   end
 end

--- a/spec/application_json_spec.rb
+++ b/spec/application_json_spec.rb
@@ -32,6 +32,10 @@ RSpec.describe ApplicationJson do
     description provider_ucas_code course_ucas_code location_ucas_code
   ].freeze
 
+  ALL_QUALIFICATION_FIELDS = %w[
+    type subject grade award_date institution_name international
+  ].freeze
+
   describe '#single_application_json' do
     subject(:parsed_json) do
       JSON.parse(including_class.single_application_json)
@@ -115,6 +119,26 @@ RSpec.describe ApplicationJson do
     it 'contains an entry for all the relevant fields' do
       fields = including_class.course_attributes.map { |desc| desc[:name] }
       expect(fields).to match_array(ALL_COURSE_FIELDS)
+    end
+  end
+
+  describe '#qualification_json' do
+    subject(:parsed_json) do
+      JSON.parse(including_class.qualification_json)
+    end
+
+    it 'returns the JSON for a qualification with all the fields present' do
+      expect(parsed_json).to be_a Hash
+      expect(parsed_json.keys).to match_array(ALL_QUALIFICATION_FIELDS)
+    end
+  end
+
+  describe '#qualification_attributes' do
+    it 'contains an entry for all the relevant fields' do
+      fields = including_class.qualification_attributes.map do |desc|
+        desc[:name]
+      end
+      expect(fields).to match_array(ALL_QUALIFICATION_FIELDS)
     end
   end
 end

--- a/spec/application_json_spec.rb
+++ b/spec/application_json_spec.rb
@@ -48,6 +48,10 @@ RSpec.describe ApplicationJson do
     course date conditions
   ].freeze
 
+  ALL_WITHDRAWAL_FIELDS = %w[
+    reason date
+  ].freeze
+
   describe '#single_application_json' do
     subject(:parsed_json) do
       JSON.parse(including_class.single_application_json)
@@ -231,6 +235,26 @@ RSpec.describe ApplicationJson do
         desc[:name]
       end
       expect(fields).to match_array(ALL_OFFER_FIELDS)
+    end
+  end
+
+  describe '#withdrawal_json' do
+    subject(:parsed_json) do
+      JSON.parse(including_class.withdrawal_json)
+    end
+
+    it 'returns the JSON for a qualification with all the fields present' do
+      expect(parsed_json).to be_a Hash
+      expect(parsed_json.keys).to match_array(ALL_WITHDRAWAL_FIELDS)
+    end
+  end
+
+  describe '#withdrawal_attributes' do
+    it 'contains an entry for all the relevant fields' do
+      fields = including_class.withdrawal_attributes.map do |desc|
+        desc[:name]
+      end
+      expect(fields).to match_array(ALL_WITHDRAWAL_FIELDS)
     end
   end
 end

--- a/spec/application_json_spec.rb
+++ b/spec/application_json_spec.rb
@@ -44,6 +44,10 @@ RSpec.describe ApplicationJson do
     booked_at date instructions address
   ].freeze
 
+  ALL_OFFER_FIELDS = %w[
+    course date conditions
+  ].freeze
+
   describe '#single_application_json' do
     subject(:parsed_json) do
       JSON.parse(including_class.single_application_json)
@@ -207,6 +211,26 @@ RSpec.describe ApplicationJson do
         desc[:name]
       end
       expect(fields).to match_array(ALL_INTERVIEW_FIELDS)
+    end
+  end
+
+  describe '#offer_json' do
+    subject(:parsed_json) do
+      JSON.parse(including_class.offer_json)
+    end
+
+    it 'returns the JSON for a qualification with all the fields present' do
+      expect(parsed_json).to be_a Hash
+      expect(parsed_json.keys).to match_array(ALL_OFFER_FIELDS)
+    end
+  end
+
+  describe '#offer_attributes' do
+    it 'contains an entry for all the relevant fields' do
+      fields = including_class.offer_attributes.map do |desc|
+        desc[:name]
+      end
+      expect(fields).to match_array(ALL_OFFER_FIELDS)
     end
   end
 end

--- a/spec/application_json_spec.rb
+++ b/spec/application_json_spec.rb
@@ -43,4 +43,11 @@ RSpec.describe ApplicationJson do
       end)
     end
   end
+
+  describe '#application_attributes' do
+    it 'contains an entry for all the relevant fields' do
+      fields = including_class.application_attributes.map { |desc| desc[:name] }
+      expect(fields).to match_array(ALL_APPLICATION_FIELDS)
+    end
+  end
 end

--- a/spec/application_json_spec.rb
+++ b/spec/application_json_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe ApplicationJson do
     end.new
   end
 
-  ALL_APPLICATION_FIELDS = %w[
+  APPLICATION_FIELDS = %w[
     id candidate contact_details course qualifications
     work_experiences status status_ucas_code personal_statement
     withdrawal rejection offer interviews created_at updated_at
@@ -17,42 +17,42 @@ RSpec.describe ApplicationJson do
   APPLICATION_SUBRESOURCES = %w[
     candidate contact_details course qualifications
     work_experiences withdrawal rejection offer interviews
-  ]
+  ].freeze
 
-  ALL_CANDIDATE_FIELDS = %w[
+  CANDIDATE_FIELDS = %w[
     id email first_name last_name date_of_birth nationality
     residency_status disability disability_hesa_code
   ].freeze
 
-  ALL_CONTACT_DETAILS_FIELDS = %w[
+  CONTACT_DETAILS_FIELDS = %w[
     phone_number address
   ].freeze
 
-  ALL_COURSE_FIELDS = %w[
+  COURSE_FIELDS = %w[
     description provider_ucas_code course_ucas_code location_ucas_code
   ].freeze
 
-  ALL_QUALIFICATION_FIELDS = %w[
+  QUALIFICATION_FIELDS = %w[
     type subject grade award_date institution_name international
   ].freeze
 
-  ALL_WORK_EXPERIENCE_FIELDS = %w[
+  WORK_EXPERIENCE_FIELDS = %w[
     employer_name start_date end_date job_title job_description
   ].freeze
 
-  ALL_INTERVIEW_FIELDS = %w[
+  INTERVIEW_FIELDS = %w[
     booked_at date instructions address
   ].freeze
 
-  ALL_OFFER_FIELDS = %w[
+  OFFER_FIELDS = %w[
     course date conditions
   ].freeze
 
-  ALL_WITHDRAWAL_FIELDS = %w[
+  WITHDRAWAL_FIELDS = %w[
     reason date
   ].freeze
-  
-  ALL_REJECTION_FIELDS = %w[
+
+  REJECTION_FIELDS = %w[
     reason date
   ].freeze
 
@@ -63,7 +63,7 @@ RSpec.describe ApplicationJson do
 
     it 'returns the JSON for an application with all fields present' do
       expect(parsed_json).to be_a Hash
-      expect(parsed_json.keys).to match_array(ALL_APPLICATION_FIELDS)
+      expect(parsed_json.keys).to match_array(APPLICATION_FIELDS)
     end
 
     it 'does not have a withdrawal or rejection' do
@@ -74,17 +74,17 @@ RSpec.describe ApplicationJson do
     it 'does not include subresources' do
       expect(parsed_json.values_at(*APPLICATION_SUBRESOURCES))
         .to all(satisfy do |v|
-          v.nil? ||
-          v == ApplicationJson::DUMMY_OBJECT ||
-          v == ApplicationJson::DUMMY_ARRAY_OF_OBJECTS
-      end)
+                  v.nil? ||
+                  v == ApplicationJson::DUMMY_OBJECT ||
+                  v == ApplicationJson::DUMMY_ARRAY_OF_OBJECTS
+                end)
     end
   end
 
   describe '#application_attributes' do
     it 'contains an entry for all the relevant fields' do
       fields = including_class.application_attributes.map { |desc| desc[:name] }
-      expect(fields).to match_array(ALL_APPLICATION_FIELDS)
+      expect(fields).to match_array(APPLICATION_FIELDS)
     end
   end
 
@@ -95,14 +95,14 @@ RSpec.describe ApplicationJson do
 
     it 'returns the JSON for a candidate with all the fields present' do
       expect(parsed_json).to be_a Hash
-      expect(parsed_json.keys).to match_array(ALL_CANDIDATE_FIELDS)
+      expect(parsed_json.keys).to match_array(CANDIDATE_FIELDS)
     end
   end
 
   describe '#candidate_attributes' do
     it 'contains an entry for all the relevant fields' do
       fields = including_class.candidate_attributes.map { |desc| desc[:name] }
-      expect(fields).to match_array(ALL_CANDIDATE_FIELDS)
+      expect(fields).to match_array(CANDIDATE_FIELDS)
     end
   end
 
@@ -113,14 +113,14 @@ RSpec.describe ApplicationJson do
 
     it 'returns the JSON for a candidate with all the fields present' do
       expect(parsed_json).to be_a Hash
-      expect(parsed_json.keys).to match_array(ALL_CONTACT_DETAILS_FIELDS)
+      expect(parsed_json.keys).to match_array(CONTACT_DETAILS_FIELDS)
     end
   end
 
   describe '#candidate_attributes' do
     it 'contains an entry for all the relevant fields' do
       fields = including_class.contact_details_attributes.map { |desc| desc[:name] }
-      expect(fields).to match_array(ALL_CONTACT_DETAILS_FIELDS)
+      expect(fields).to match_array(CONTACT_DETAILS_FIELDS)
     end
   end
 
@@ -131,14 +131,14 @@ RSpec.describe ApplicationJson do
 
     it 'returns the JSON for a course with all the fields present' do
       expect(parsed_json).to be_a Hash
-      expect(parsed_json.keys).to match_array(ALL_COURSE_FIELDS)
+      expect(parsed_json.keys).to match_array(COURSE_FIELDS)
     end
   end
 
   describe '#course_attributes' do
     it 'contains an entry for all the relevant fields' do
       fields = including_class.course_attributes.map { |desc| desc[:name] }
-      expect(fields).to match_array(ALL_COURSE_FIELDS)
+      expect(fields).to match_array(COURSE_FIELDS)
     end
   end
 
@@ -149,7 +149,7 @@ RSpec.describe ApplicationJson do
 
     it 'returns the JSON for a qualification with all the fields present' do
       expect(parsed_json).to be_a Hash
-      expect(parsed_json.keys).to match_array(ALL_QUALIFICATION_FIELDS)
+      expect(parsed_json.keys).to match_array(QUALIFICATION_FIELDS)
     end
   end
 
@@ -158,7 +158,7 @@ RSpec.describe ApplicationJson do
       fields = including_class.qualification_attributes.map do |desc|
         desc[:name]
       end
-      expect(fields).to match_array(ALL_QUALIFICATION_FIELDS)
+      expect(fields).to match_array(QUALIFICATION_FIELDS)
     end
   end
 
@@ -169,7 +169,7 @@ RSpec.describe ApplicationJson do
 
     it 'returns the JSON for a qualification with all the fields present' do
       expect(parsed_json).to be_a Hash
-      expect(parsed_json.keys).to match_array(ALL_WORK_EXPERIENCE_FIELDS)
+      expect(parsed_json.keys).to match_array(WORK_EXPERIENCE_FIELDS)
     end
   end
 
@@ -178,7 +178,7 @@ RSpec.describe ApplicationJson do
       fields = including_class.work_experience_attributes.map do |desc|
         desc[:name]
       end
-      expect(fields).to match_array(ALL_WORK_EXPERIENCE_FIELDS)
+      expect(fields).to match_array(WORK_EXPERIENCE_FIELDS)
     end
   end
 
@@ -189,7 +189,7 @@ RSpec.describe ApplicationJson do
 
     it 'returns the JSON for a qualification with all the fields present' do
       expect(parsed_json).to be_a Hash
-      expect(parsed_json.keys).to match_array(ALL_WORK_EXPERIENCE_FIELDS)
+      expect(parsed_json.keys).to match_array(WORK_EXPERIENCE_FIELDS)
     end
   end
 
@@ -198,7 +198,7 @@ RSpec.describe ApplicationJson do
       fields = including_class.work_experience_attributes.map do |desc|
         desc[:name]
       end
-      expect(fields).to match_array(ALL_WORK_EXPERIENCE_FIELDS)
+      expect(fields).to match_array(WORK_EXPERIENCE_FIELDS)
     end
   end
 
@@ -209,7 +209,7 @@ RSpec.describe ApplicationJson do
 
     it 'returns the JSON for a qualification with all the fields present' do
       expect(parsed_json).to be_a Hash
-      expect(parsed_json.keys).to match_array(ALL_INTERVIEW_FIELDS)
+      expect(parsed_json.keys).to match_array(INTERVIEW_FIELDS)
     end
   end
 
@@ -218,7 +218,7 @@ RSpec.describe ApplicationJson do
       fields = including_class.interview_attributes.map do |desc|
         desc[:name]
       end
-      expect(fields).to match_array(ALL_INTERVIEW_FIELDS)
+      expect(fields).to match_array(INTERVIEW_FIELDS)
     end
   end
 
@@ -229,7 +229,7 @@ RSpec.describe ApplicationJson do
 
     it 'returns the JSON for a qualification with all the fields present' do
       expect(parsed_json).to be_a Hash
-      expect(parsed_json.keys).to match_array(ALL_OFFER_FIELDS)
+      expect(parsed_json.keys).to match_array(OFFER_FIELDS)
     end
   end
 
@@ -238,7 +238,7 @@ RSpec.describe ApplicationJson do
       fields = including_class.offer_attributes.map do |desc|
         desc[:name]
       end
-      expect(fields).to match_array(ALL_OFFER_FIELDS)
+      expect(fields).to match_array(OFFER_FIELDS)
     end
   end
 
@@ -249,7 +249,7 @@ RSpec.describe ApplicationJson do
 
     it 'returns the JSON for a qualification with all the fields present' do
       expect(parsed_json).to be_a Hash
-      expect(parsed_json.keys).to match_array(ALL_WITHDRAWAL_FIELDS)
+      expect(parsed_json.keys).to match_array(WITHDRAWAL_FIELDS)
     end
   end
 
@@ -258,7 +258,7 @@ RSpec.describe ApplicationJson do
       fields = including_class.withdrawal_attributes.map do |desc|
         desc[:name]
       end
-      expect(fields).to match_array(ALL_WITHDRAWAL_FIELDS)
+      expect(fields).to match_array(WITHDRAWAL_FIELDS)
     end
   end
 
@@ -269,7 +269,7 @@ RSpec.describe ApplicationJson do
 
     it 'returns the JSON for a qualification with all the fields present' do
       expect(parsed_json).to be_a Hash
-      expect(parsed_json.keys).to match_array(ALL_REJECTION_FIELDS)
+      expect(parsed_json.keys).to match_array(REJECTION_FIELDS)
     end
   end
 
@@ -278,7 +278,7 @@ RSpec.describe ApplicationJson do
       fields = including_class.rejection_attributes.map do |desc|
         desc[:name]
       end
-      expect(fields).to match_array(ALL_REJECTION_FIELDS)
+      expect(fields).to match_array(REJECTION_FIELDS)
     end
   end
 end

--- a/spec/application_json_spec.rb
+++ b/spec/application_json_spec.rb
@@ -281,4 +281,13 @@ RSpec.describe ApplicationJson do
       expect(fields).to match_array(REJECTION_FIELDS)
     end
   end
+
+  describe '#link_to_resource_definition' do
+    it 'links to the correct page' do
+      result = including_class.link_to_resource_definition('Arbitrary field name')
+      link = '/resources-and-their-attributes#arbitrary-field-name'
+      expected = "<a href='#{link}'>Arbitrary field name</a>"
+      expect(result).to eq(expected)
+    end
+  end
 end

--- a/spec/application_json_spec.rb
+++ b/spec/application_json_spec.rb
@@ -40,6 +40,10 @@ RSpec.describe ApplicationJson do
     employer_name start_date end_date job_title job_description
   ].freeze
 
+  ALL_INTERVIEW_FIELDS = %w[
+    booked_at date instructions address
+  ].freeze
+
   describe '#single_application_json' do
     subject(:parsed_json) do
       JSON.parse(including_class.single_application_json)
@@ -183,6 +187,26 @@ RSpec.describe ApplicationJson do
         desc[:name]
       end
       expect(fields).to match_array(ALL_WORK_EXPERIENCE_FIELDS)
+    end
+  end
+
+  describe '#interview_json' do
+    subject(:parsed_json) do
+      JSON.parse(including_class.interview_json)
+    end
+
+    it 'returns the JSON for a qualification with all the fields present' do
+      expect(parsed_json).to be_a Hash
+      expect(parsed_json.keys).to match_array(ALL_INTERVIEW_FIELDS)
+    end
+  end
+
+  describe '#interview_attributes' do
+    it 'contains an entry for all the relevant fields' do
+      fields = including_class.interview_attributes.map do |desc|
+        desc[:name]
+      end
+      expect(fields).to match_array(ALL_INTERVIEW_FIELDS)
     end
   end
 end

--- a/spec/application_json_spec.rb
+++ b/spec/application_json_spec.rb
@@ -24,6 +24,10 @@ RSpec.describe ApplicationJson do
     residency_status disability disability_hesa_code
   ].freeze
 
+  ALL_CONTACT_DETAILS_FIELDS = %w[
+    phone_number address
+  ].freeze
+
   describe '#single_application_json' do
     subject(:parsed_json) do
       JSON.parse(including_class.single_application_json)
@@ -87,7 +91,7 @@ RSpec.describe ApplicationJson do
 
   describe '#candidate_attributes' do
     it 'contains an entry for all the relevant fields' do
-      fields = including_class.contact_details_json.map { |desc| desc[:name] }
+      fields = including_class.contact_details_attributes.map { |desc| desc[:name] }
       expect(fields).to match_array(ALL_CONTACT_DETAILS_FIELDS)
     end
   end

--- a/spec/application_json_spec.rb
+++ b/spec/application_json_spec.rb
@@ -51,6 +51,10 @@ RSpec.describe ApplicationJson do
   ALL_WITHDRAWAL_FIELDS = %w[
     reason date
   ].freeze
+  
+  ALL_REJECTION_FIELDS = %w[
+    reason date
+  ].freeze
 
   describe '#single_application_json' do
     subject(:parsed_json) do
@@ -255,6 +259,26 @@ RSpec.describe ApplicationJson do
         desc[:name]
       end
       expect(fields).to match_array(ALL_WITHDRAWAL_FIELDS)
+    end
+  end
+
+  describe '#rejection_json' do
+    subject(:parsed_json) do
+      JSON.parse(including_class.rejection_json)
+    end
+
+    it 'returns the JSON for a qualification with all the fields present' do
+      expect(parsed_json).to be_a Hash
+      expect(parsed_json.keys).to match_array(ALL_REJECTION_FIELDS)
+    end
+  end
+
+  describe '#rejection_attributes' do
+    it 'contains an entry for all the relevant fields' do
+      fields = including_class.rejection_attributes.map do |desc|
+        desc[:name]
+      end
+      expect(fields).to match_array(ALL_REJECTION_FIELDS)
     end
   end
 end

--- a/spec/features/following_resource_links_spec.rb
+++ b/spec/features/following_resource_links_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
-RSpec.describe 'following resource links', type: :feature do
-  scenario 'clicking the "Candidate" link in the "Application" attributes list' do
+describe 'following resource links', type: :feature do
+  scenario 'clicking the "Contact details" link in the "Application" attributes list' do
     visit '/'
 
     click_on 'Retrieve a single application'
@@ -9,6 +9,6 @@ RSpec.describe 'following resource links', type: :feature do
       click_on 'Candidate'
     end
 
-    expect(page).to have_content 'The unique ID of this candidate'
+    expect(page).to have_content 'The candidate’s phone number'
   end
 end


### PR DESCRIPTION
Add JSON and attribute definitions for the remaining API entities.

The specs are very heavily duplicated, but we feel ok about this and are happy to postpone refactoring to the next round of requirements.