### PR TITLE
Remove UCAS status code

### DIFF
--- a/lib/application.json
+++ b/lib/application.json
@@ -1,7 +1,6 @@
 {
   "id": "aa546741-b54a-403c-a67a-7f5aec1939d1",
   "status": "open",
-  "status_ucas_code": "C",
   "personal_statement": "Since retiring from the Police Service in 2007...",
   "candidate": {
     "id": "a0afe017-ea18-491d-9bda-16037102e1dd",

--- a/lib/application_json.rb
+++ b/lib/application_json.rb
@@ -32,11 +32,6 @@ module ApplicationJson
         description: 'The status of this application'
       },
       {
-        name: 'status_ucas_code',
-        type: 'string',
-        description: 'The status of this application in legacy UCAS code format'
-      },
-      {
         name: 'personal_statement',
         type: 'string',
         description: 'The candidate’s personal statement'

--- a/spec/application_json_spec.rb
+++ b/spec/application_json_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe ApplicationJson do
 
   APPLICATION_FIELDS = %w[
     id candidate contact_details course qualifications
-    work_experiences status status_ucas_code personal_statement
+    work_experiences status personal_statement
     withdrawal rejection offer interviews placement created_at updated_at
   ].freeze
 


### PR DESCRIPTION
Unexpectedly, UCAS status codes are not particularly 'coded' - they often include a natural-language description of the status (alongside some domain-specific coding that is difficult to immediately understand).

For this reason, we'll start with just a DfE status and discover if that meets needs.