### PR TITLE
Address feedback

### DIFF
--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -35,4 +35,4 @@ max_toc_heading_level: 6
 prevent_indexing: false
 
 show_contribution_banner: true
-github_repo: DFE-Digital/apply-for-postgraduate-teacher-training
+github_repo: DFE-Digital/apply-for-postgraduate-teacher-training-tech-docs

--- a/lib/application_json.rb
+++ b/lib/application_json.rb
@@ -34,7 +34,7 @@ module ApplicationJson
       {
         name: 'personal_statement',
         type: 'string',
-        description: 'The candidate’s personal statement'
+        description: 'The candidate’s personal statement - this can be up to 500 characters'
       },
       {
         name: 'offer',
@@ -118,12 +118,12 @@ module ApplicationJson
       {
         name: 'first_name',
         type: 'string',
-        description: 'The candidate’s first name'
+        description: 'The candidate’s first name - this can be up to 60 characters'
       },
       {
         name: 'last_name',
         type: 'string',
-        description: 'The candidate’s last name'
+        description: 'The candidate’s last name - this can be up to 60 characters'
       },
       {
         name: 'date_of_birth',

--- a/source/confirm_a_candidates_place_on_your_course.html.md.erb
+++ b/source/confirm_a_candidates_place_on_your_course.html.md.erb
@@ -1,9 +1,9 @@
 ---
-title: Confirm a placement
+title: Confirm a candidate's place on your course
 weight: 50
 ---
 
-# Confirm a placement
+# Confirm a candidate's place on your course
 
 ```
 POST /applications/:id/placement

--- a/source/get-help.html.md.erb
+++ b/source/get-help.html.md.erb
@@ -5,7 +5,6 @@ weight: 100
 
 # Get help
 
-If you have any questions or suggestions [contact the Becoming a Teacher
-team](mailto:becomingateacher@digital.education.gov.uk).
+If you have any questions or suggestions [contact us](mailto:becomingateacher@digital.education.gov.uk) at becomingateacher@digital.education.gov.uk.
 
 We’ll try to get back to you within two working days.

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -22,6 +22,8 @@ The API is a work in progress. We are publishing draft documentation so that
 - confirming a candidate's place on your course
 - rejecting unsuccessful applications
 
+We're still working on how the service will deal with combinations of these processes. We're seeking your feedback on these to help improve it.
+
 ## How do I connect to this API?
 
 **This is a working draft specification**.

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -30,6 +30,8 @@ We're still working on how the service will deal with combinations of these proc
 
 We are currently building the service. The API has not yet been implemented.
 
-Testing environments for each vendor will be available before the service moves into public beta.
+We're working with all vendors on timelines for integration. As part of this, we'll make private testing environments available.
+
+If you need information about what we're working on now and next, [contact us](mailto:becomingateacher@digital.education.gov.uk) at becomingateacher@digital.education.gov.uk.
 
 _Last updated: <%= Date.today.strftime("%-d %B %Y") %>_


### PR DESCRIPTION
This PR includes a number of small fixes:
- Add more information around now and next to **Introduction#What_is_this_API_for** section
- Re-title "Confirm a placement" to something more explanatory
- Add guidance on length for a few fields
- Add e-mail address explictly on 'Get help' page (as well as link)
- Fix footer github links 

Notably, this doesn't include:
- Add a way of contacting us (email?) to the footer