### PR TITLE
Incorporate feedback from Capita meeting

### DIFF
--- a/lib/application.json
+++ b/lib/application.json
@@ -51,9 +51,7 @@
   }],
   "interviews": [{
     "booked_at": "2019-01-16T14:00:00Z",
-    "date": "2019-01-18T10:30:00Z",
-    "instructions": "Come to Room 4 in Building 6",
-    "address": "Acorns Teaching School Alliance HQ, 1 Romney Way, Doncaster, DN1 8TQ"
+    "date": "2019-01-18T10:30:00Z"
   },
   {
     "booked_at": "2019-01-19T09:00:00Z",

--- a/lib/application.json
+++ b/lib/application.json
@@ -18,7 +18,7 @@
     "address": "45 Dialstone Lane, Stockport, England SK2 6AA"
   },
   "course": {
-    "description": "Acorns Teaching School Alliance, Primary (salaried, full-time)",
+    "description": "Acorns Teaching School Alliance, Oxford Oakleaf Campus, Primary (salaried, full-time) PGCE, September 2020",
     "start_date": "2020-09-10",
     "provider_ucas_code": "2FR",
     "course_ucas_code": "3CVK",
@@ -70,7 +70,7 @@
   }],
   "offer": {
     "course": {
-      "description": "Acorns Teaching School Alliance, Primary (salaried, full-time)",
+      "description": "Acorns Teaching School Alliance, Oxford Oakleaf Campus, Primary (salaried, full-time) PGCE, September 2020",
       "provider_ucas_code": "2FR",
       "course_ucas_code": "3CVK",
       "location_ucas_code": "K"

--- a/lib/application_json.rb
+++ b/lib/application_json.rb
@@ -105,6 +105,17 @@ module ApplicationJson
     ]
   end
 
+  def applications_params
+    [
+      {
+        name: 'since',
+        type: 'string',
+        description: 'Optional. Include only applications changed or created on
+        or since a date and time. Times should be in ISO8601 format.'
+      }
+    ]
+  end
+
   def candidate_json
     JSON.pretty_generate(json_data['candidate'])
   end

--- a/lib/application_json.rb
+++ b/lib/application_json.rb
@@ -352,16 +352,6 @@ module ApplicationJson
         name: 'date',
         type: 'string',
         description: 'The ISO8601 date and time this interview takes place'
-      },
-      {
-        name: 'instructions',
-        type: 'string',
-        description: 'Instructions to the candidate'
-      },
-      {
-        name: 'address',
-        type: 'string',
-        description: 'The address of the building where the interview takes place'
       }
     ]
   end

--- a/lib/application_json.rb
+++ b/lib/application_json.rb
@@ -198,7 +198,9 @@ module ApplicationJson
       {
         name: 'description',
         type: 'string',
-        description: 'The plain text description of the course'
+        description: 'A plain text description of the course, composed of
+          English translations of the provider UCAS code, the course UCAS code,
+          the location UCAS code, and the start date'
       },
       {
         name: 'start_date',

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -30,6 +30,18 @@ Vendors will be able to gain access to Apply data on these users’ behalf via a
 
 We're still working on how the service will deal with combinations of these processes. We're seeking your feedback on these to help improve it.
 
+## Codes and reference data
+
+Before each application cycle, UCAS provides vendors with reference data defining how certain values appear in API responses.
+
+DfE Apply will avoid prioprietary codes wherever possible, preferring existing data formats such as ISO-certified standards or HESA codes.
+
+Currently this happens in three places:
+
+- All dates in in the API specification are intended to be ISO8601 compliant.
+- Nationality is expressed as an ISO3611 country code.
+- Disability is expressed as a [HESA Disability type code](https://www.hesa.ac.uk/collection/student/datafutures/a/disability_disability)
+
 ## How do I connect to this API?
 
 **This is a working draft specification**.

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -14,6 +14,12 @@ The API is a work in progress. We are publishing draft documentation so that
 - providers and vendors have all the information they need to plan a transition to the new service
 - the Apply team can better understand providers’ and vendors’ needs for the API
 
+## Authentication and authorization
+
+Staff at training providers will identify themselves to Apply via [DfE Sign In](https://sa.education.gov.uk/).
+
+Vendors will be able to gain access to Apply data on these users’ behalf via an automated authorization process such as OAuth2.
+
 ## What this API is for
 
 - retrieving candidate application data

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -14,21 +14,21 @@ The API is a work in progress. We are publishing draft documentation so that
 - providers and vendors have all the information they need to plan a transition to the new service
 - the Apply team can better understand providers’ and vendors’ needs for the API
 
-## Authentication and authorization
-
-Staff at training providers will identify themselves to Apply via [DfE Sign In](https://sa.education.gov.uk/).
-
-Vendors will be able to gain access to Apply data on these users’ behalf via an automated authorization process such as OAuth2.
-
 ## What this API is for
 
+Once a candidate has submitted their application via the Apply service, the
+application will become available over the API.
+
+Providers can then use the API for
+
+- reviewing applications
 - retrieving candidate application data
 - inviting candidates to interview
 - making (or amending) offers to candidates
-- confirming a candidate's place on your course
+- confirming a candidate's place on a course
 - rejecting unsuccessful applications
 
-We're still working on how the service will deal with combinations of these processes. We're seeking your feedback on these to help improve it.
+To get an idea of how the API works, we recommend you [review the example usage scenarios](/usage-scenarios).
 
 ## Codes and reference data
 

--- a/source/retrieve-many-applications.html.md.erb
+++ b/source/retrieve-many-applications.html.md.erb
@@ -12,8 +12,12 @@ GET /applications
 ## Example request
 
 ```
-GET /applications/:id
+GET /applications/:id?since=2018-10-01T10:00:00Z
 ```
+
+## Query parameters
+
+<%= partial 'partials/attribute_table', locals: { attributes: applications_params } %>
 
 ## Example response
 

--- a/source/usage-scenarios.html.md.erb
+++ b/source/usage-scenarios.html.md.erb
@@ -1,0 +1,94 @@
+---
+title: Usage scenarios
+weight: 80
+---
+
+# Usage scenarios
+
+The examples on this page show typical request URLs and payloads clients can
+use to take actions via this API. The examples are only concerned with business
+logic and contain no details necessary for real-world usage. For example,
+authentication is completely left out.
+
+At the beginning of each scenario, a candidate has completed an application for initial teacher training via the Apply service and that application is available via the API.
+
+The provider has authenticated to your system and begins their work by retrieving all the applications since a given date. Your system issues the following request on their behalf:
+
+```
+GET /applications?since=2019-01-10
+```
+
+This returns a list of <%= link_to_resource_definition('Application') %>s.
+
+## A successful application (3 steps)
+
+**1. The provider invites the candidate to interview.**
+
+`POST /applications/abc-123/interview`
+
+
+```json
+<%= interview_json %>
+```
+
+The interview goes well. The provider would like to offer the candidate a conditional place.
+
+**2. The provider makes an offer**
+
+`POST /applications/abc-123/offer`
+
+```json
+<%= offer_json %>
+```
+
+The candidate goes on to meet the provider’s conditions. The provider indicates that the candidate has a place.
+
+**3. The provider confirms the candidate’s place**
+
+`POST /applications/abc-123/placement`
+
+```json
+<%= placement_json %>
+```
+
+## An unsuccessful application (3 steps)
+
+**1. The provider invites the candidate to interview.**
+
+`POST /applications/abc-123/interview`
+
+```json
+<%= interview_json %>
+```
+
+**2. The provider makes an offer**
+
+The interview went well. The provider would like to offer the candidate a conditional place.
+
+`POST /applications/abc-123/offer`
+
+```json
+<%= offer_json %>
+```
+
+**3. The provider rejects the candidate**
+
+The candidate did not meet the provider’s conditions. The provider rejects them.
+
+`POST /applications/abc-123/rejection`
+
+```json
+<%= rejection_json %>
+```
+
+## Rejecting an application (1 step)
+
+**1. The provider reviews the form and rejects the candidate without an interview**
+
+`POST /applications/abc-123/rejection`
+
+```json
+<%= rejection_json %>
+```
+
+## 

--- a/spec/application_json_spec.rb
+++ b/spec/application_json_spec.rb
@@ -21,6 +21,10 @@ RSpec.describe ApplicationJson do
     references
   ].freeze
 
+  APPLICATIONS_PARAMS = %w[
+    since
+  ].freeze
+
   CANDIDATE_FIELDS = %w[
     id first_name last_name date_of_birth nationality
     uk_residency_status disability disability_hesa_code
@@ -97,6 +101,13 @@ RSpec.describe ApplicationJson do
     it 'contains an entry for all the relevant fields' do
       fields = including_class.application_attributes.map { |desc| desc[:name] }
       expect(fields).to match_array(APPLICATION_FIELDS)
+    end
+  end
+
+  describe '#applications_params' do
+    it 'contains an entry for all the relevant fields' do
+      fields = including_class.applications_params.map { |desc| desc[:name] }
+      expect(fields).to match_array(APPLICATIONS_PARAMS)
     end
   end
 

--- a/spec/application_json_spec.rb
+++ b/spec/application_json_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe ApplicationJson do
   ].freeze
 
   INTERVIEW_FIELDS = %w[
-    booked_at date instructions address
+    booked_at date
   ].freeze
 
   OFFER_FIELDS = %w[

--- a/spec/features/following_internal_links_spec.rb
+++ b/spec/features/following_internal_links_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe 'following resource links', type: :feature do
+describe 'following internal links', type: :feature do
   scenario 'clicking the "Contact details" link in the "Application" attributes list' do
     visit '/'
 
@@ -10,5 +10,15 @@ describe 'following resource links', type: :feature do
     end
 
     expect(page).to have_content 'The candidate’s phone number'
+  end
+
+  scenario 'clicking the "Usage scenarios" link on the front page' do
+    visit '/'
+
+    within '#content' do
+      click_on 'usage scenarios'
+    end
+
+    expect(page).to have_content 'A successful application'
   end
 end


### PR DESCRIPTION
- Add Usage scenarios to flesh out business logic
- Add a section on Codes and reference data, to put some distance
between us and UCAS, with their many proprietary encodings
- Remove non-date information from the Interview resource, because
we’re not an interview booking service
- Document the Course "description" field and improve the specimen data
- Document a since= query param in GET /applications
- Add a note about authorization via DfE Sign-In

## Course and interview resources

<img width="678" alt="Screenshot 2019-07-01 at 16 34 51" src="https://user-images.githubusercontent.com/642279/60448819-4c9fbe00-9c1e-11e9-8b53-be3280300c7c.png">

<img width="819" alt="Screenshot 2019-07-01 at 16 35 44" src="https://user-images.githubusercontent.com/642279/60448839-55908f80-9c1e-11e9-9eef-c2eaec069d7f.png">


## New sections on front page

<img width="597" alt="Screenshot 2019-07-01 at 16 32 51" src="https://user-images.githubusercontent.com/642279/60448660-fb8fca00-9c1d-11e9-835b-28787e7190d0.png">

## A usage scenario

<img width="646" alt="Screenshot 2019-07-01 at 16 33 08" src="https://user-images.githubusercontent.com/642279/60448682-03e80500-9c1e-11e9-8078-a72c8f0d4388.png">

## Documenting the `since` URL parameter

<img width="629" alt="Screenshot 2019-07-01 at 16 33 19" src="https://user-images.githubusercontent.com/642279/60448719-16fad500-9c1e-11e9-9306-d6847bf1b8a1.png">
