### PR TITLE
Add attributes table for Make an Offer

### DIFF
--- a/source/make-an-offer.html.md.erb
+++ b/source/make-an-offer.html.md.erb
@@ -28,3 +28,7 @@ Request body:
 ```json
 <%= offer_json %>
 ```
+
+## Attributes
+
+<%= partial 'partials/attribute_table', locals: { attributes: offer_attributes } %>


### PR DESCRIPTION
### Context

When going through current Cucumber specs alongside the API docs, we found that there were some small inconsistencies and redundant attributes.

### Changes proposed in this pull request

Add attributes table for `Make an Offer` so that it's the same as `Amend an Offer`.

### Guidance to review

On the Trello card, there was a point about adding who can make offers but we decided to leave this out for now until we have a clearer understanding of authentication.

### Link to Trello card

[877 - Update made an offer and amend an offer endpoints to remove inconsistencies](https://trello.com/c/Dp4ZSvvL/877-update-made-an-offer-and-amend-an-offer-endpoints)
