### PR TITLE
Link ISO code guidance to API docs

### DIFF
--- a/lib/application_json.rb
+++ b/lib/application_json.rb
@@ -89,12 +89,12 @@ module ApplicationJson
       {
         name: 'submitted_at',
         type: 'string',
-        description: 'ISO8601 date of submission, with time and timezone'
+        description: 'ISO 8601 date of submission, with time and timezone'
       },
       {
         name: 'updated_at',
         type: 'string',
-        description: 'ISO8601 date of last change, with time and timezone'
+        description: 'ISO 8601 date of last change, with time and timezone'
       }
     ]
   end
@@ -105,7 +105,7 @@ module ApplicationJson
         name: 'since',
         type: 'string',
         description: 'Optional. Include only applications changed or created on
-        or since a date and time. Times should be in ISO8601 format.'
+        or since a date and time. Times should be in ISO 8601 format.'
       }
     ]
   end
@@ -139,7 +139,7 @@ module ApplicationJson
       {
         name: 'nationality',
         type: 'string',
-        description: 'The candidate’s nationality as an ISO3166 country code'
+        description: 'The candidate’s nationality as an ISO 3166 country code'
       },
       {
         name: 'uk_residency_status',
@@ -258,7 +258,7 @@ module ApplicationJson
       {
         name: 'awarding_body_country',
         type: 'string',
-        description: 'The awarding body’s country as an ISO3166 country code'
+        description: 'The awarding body’s country as an ISO 3166 country code'
       }
     ]
   end

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -38,7 +38,7 @@ DfE Apply will avoid prioprietary codes wherever possible, preferring existing d
 Codes appear in three contexts:
 
 - All dates in in the API specification are intended to be [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) compliant
-- Nationality is expressed as an [ISO 3611](https://www.iso.org/iso-3166-country-codes.html) country code
+- Nationality is expressed as an [ISO 3166](https://www.iso.org/iso-3166-country-codes.html) country code
 - Disability is expressed as a [HESA Disability type code](https://www.hesa.ac.uk/collection/student/datafutures/a/disability_disability)
 
 ## How do I connect to this API?

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -37,8 +37,8 @@ DfE Apply will avoid prioprietary codes wherever possible, preferring existing d
 
 Codes appear in three contexts:
 
-- All dates in in the API specification are intended to be ISO8601 compliant
-- Nationality is expressed as an ISO3611 country code
+- All dates in in the API specification are intended to be [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) compliant
+- Nationality is expressed as an [ISO 3611](https://www.iso.org/iso-3166-country-codes.html) country code
 - Disability is expressed as a [HESA Disability type code](https://www.hesa.ac.uk/collection/student/datafutures/a/disability_disability)
 
 ## How do I connect to this API?


### PR DESCRIPTION
### Context

We received feedback from vendors on the API docs and want to improve our documentation based on this to make it easier for vendors to integrate with us. See https://trello.com/c/XqqL9n1H/584-tech-docs-fixes.

### Changes proposed in this pull request

- Add links to the official ISO website when ISO codes are referenced.
- Add a space between `ISO` and `<code number>` as this is how it's written in the ISO documentation.
- Fix incorrect ISO code used for country codes in `Introduction` page.

### Guidance to review

Check that references to an ISO code is correctly linked to the ISO code guidance.

### Link to Trello card

[888 - Link ISO code guidance to API docs](https://trello.com/c/BqQv08GZ/888-link-iso-code-guidance-to-api-docs)
