### PR TITLE
Add max length of strings confirmation

### DIFF
--- a/source/resources-and-their-attributes.html.md.erb
+++ b/source/resources-and-their-attributes.html.md.erb
@@ -5,6 +5,10 @@ weight: 70
 
 # Resources and their attributes
 
+## Strings
+
+For attributes that are of **string** type, they will have a maximum length of 255 characters unless specified otherwise.
+
 ## Application
 
 ```json


### PR DESCRIPTION
### Context

We received feedback from vendors on the API docs and therefore we want to improve our documentation based on this. See https://trello.com/c/XqqL9n1H/584-tech-docs-fixes.

### Changes proposed in this pull request

Add a sentence on the `Resources and attributes` page to confirm the maximum length of strings.

### Guidance to review

Some questions:
- Is this the best place to add this?
- Is this even correct?

### Link to Trello card

[889 - Add content to landing page confirming max length of strings](https://trello.com/c/TwrUhRkb/889-add-content-to-landing-page-confirming-max-length-of-strings)
