### PR TITLE
Add only candidates can withdraw an application

### DIFF
--- a/source/resources-and-their-attributes.html.md.erb
+++ b/source/resources-and-their-attributes.html.md.erb
@@ -71,6 +71,8 @@ weight: 70
 
 ## Withdrawal
 
+The withdrawal of an application can only be made by a candidate.
+
 ```json
 <%= withdrawal_json %>
 ```


### PR DESCRIPTION
### Context

We received feedback from vendors on the API docs and therefore we want to improve our documentation based on this. See https://trello.com/c/XqqL9n1H/584-tech-docs-fixes.

### Changes proposed in this pull request

Add sentence that is part of `Withdrawal` resource section to confirm that only a candidate.

### Guidance to review

- Is this the best place to add this?
- Is this all we need to say?

### Link to Trello card

[890 - Add content to withdrawal resource confirming that only candidates can withdraw an application](https://trello.com/c/Jlv5QGfZ/890-add-content-to-withdrawal-resource-confirming-that-only-candidates-can-withdraw-an-application)
