### PR TITLE
Update offer conditions to show array limit

### DIFF
--- a/lib/application_json.rb
+++ b/lib/application_json.rb
@@ -357,8 +357,8 @@ module ApplicationJson
       },
       {
         name: 'conditions',
-        type: 'array of strings',
-        description: 'The conditions of the offer'
+        type: 'array of strings [20]',
+        description: 'The conditions of the offer, limited to 20 conditions'
       }
     ]
   end


### PR DESCRIPTION
### Context

We received feedback from vendors needing clarification around how many conditions an offer can have. Therefore we want to improve our documentation to address this.

### Changes proposed in this pull request

Update the `Offer` resource to state that the conditions array is limited to 20 strings.

### Guidance to review

Check the `resource and attributes` page to ensure that the `offer` resource contains the new change.
 
### Link to Trello card

[893 - set conditions array limit](https://trello.com/c/6gex7knJ/893-set-a-limit-of-20-to-the-conditions-array)
