### PR TITLE
Deploy to production from a special branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,3 +14,4 @@ deploy:
   space: sandbox
   on:
     repo: DFE-Digital/apply-for-postgraduate-teacher-training-tech-docs
+    branch: deploy-to-production

--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@ bundle exec middleman build`
 
 Every time you run this command, the `build` folder gets generated from scratch. This means any changes to the `build` folder that are not part of the build command will get overwritten.
 
+## Deploy
+
+To deploy, create a Pull Request to merge new commits from `master` into the `deploy-to-production` branch. You can [use this compare link to create the PR](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training-tech-docs/compare/deploy-to-production...master).
+
+Once your PR is merged Travis will automatically deploy the changes.
+
 ## Troubleshooting
 
 Run `bundle update` to make sure you're using the most recent Ruby gem versions.


### PR DESCRIPTION
### Context

We want to be more deliberate in our deploys and provide a better change log for the vendors.

### Changes proposed in this pull request

This tells Travis to deploy the `deploy-to-production` branch to production whenever there are new commits. I've [created this branch off current master](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training-tech-docs/tree/deploy-to-production) and added branch protection. 

### Guidance to review

Once this is merged, I'll raise the first PR to deploy the docs.

### Link to Trello card

[900 - Set up a versioned release process for the Tech Docs app](https://trello.com/c/n4Z0AukL/900-set-up-a-versioned-release-process-for-the-tech-docs-app)
