### PR TITLE
Update course field in an application to be an object

### DIFF
--- a/lib/application_json.rb
+++ b/lib/application_json.rb
@@ -10,7 +10,7 @@ module ApplicationJson
         'offer' => nil,
         'candidate' => DUMMY_OBJECT,
         'contact_details' => DUMMY_OBJECT,
-        'course' => DUMMY_ARRAY_OF_OBJECTS,
+        'course' => DUMMY_OBJECT,
         'work_experiences' => DUMMY_ARRAY_OF_OBJECTS,
         'references' => DUMMY_ARRAY_OF_OBJECTS,
         'qualifications' => DUMMY_ARRAY_OF_OBJECTS


### PR DESCRIPTION
### Context

Currently in our `Application` resource, it has a `condition` field that contains an array of `Course`s. This suggests that a provider will know the other courses a candidate has applied for.

### Changes proposed in this pull request

Update `course` field in the `Application` resource to be an object instead of an array of `Course`s.

### Guidance to review

Double check this is the only change required.

### Link to Trello card

[903 - Update Application resource to only contain a single course in the API docs](https://trello.com/c/KbTOtGVJ/903-update-application-resource-to-only-contain-a-single-course-in-the-api-docs)
