### PR TITLE
Add release notes

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,6 +8,10 @@ Why are you making this change? What might surprise someone about it?
 
 How could someone else check this work? Which parts do you want more feedback on?
 
+### Release notes
+
+- [ ] [If needed](/README.md#release-notes), the [release notes](/source/release-notes.html.md) have been updated
+
 ### Link to Trello card
 
 [123 - Example Trello card](http://trello.com/123-example-card)

--- a/README.md
+++ b/README.md
@@ -46,6 +46,20 @@ To deploy, create a Pull Request to merge new commits from `master` into the `de
 
 Once your PR is merged Travis will automatically deploy the changes.
 
+### Release notes
+
+Each deploy should be accompanied by an update to the release notes.
+
+We only add:
+
+- Functionality changes like https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training-tech-docs/pull/31 and https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training-tech-docs/pull/23. These are most important and should always be on the top.
+- Clarifications that might impact assumptions of vendors like https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training-tech-docs/pull/27. These are less important and go into a "Additional changes" section.
+
+We don't include the following in the release notes:
+
+- Typo fixes, unless the typo is significant and could cause confusion or misunderstanding
+- Internal work like gem upgrades
+
 ## Troubleshooting
 
 Run `bundle update` to make sure you're using the most recent Ruby gem versions.

--- a/source/release-notes.html.md
+++ b/source/release-notes.html.md
@@ -1,0 +1,24 @@
+---
+title: Release notes
+weight: 200
+---
+
+# Release notes
+
+### Release 0.2 - 11 September 2019
+
+- Limit the number of [offer conditions](/make-an-offer/#attributes) to 20
+- Remove functionality to confirm a placement for a candidate
+- Remove functionality to schedule interviews for a candidate
+- Applications now have a [10 character identifier](/resources-and-their-attributes/#application)
+- The [`course` attribute](/retrieve-a_single-application) of an application now refers to a single course instead of multiple
+
+Additional changes:
+
+- Clarify that strings have a [255 character limit](/resources-and-their-attributes/#strings), unless otherwise specified
+- Clarify that only candidates can [withdraw an application](/resources-and-their-attributes/#withdrawal)
+- Clarify that we're using [ISO 3166 dates](/#codes-and-reference-data) (not ISO3611)
+
+### Release 0.1 - 4 July 2019
+
+Initial release of the API documentation.


### PR DESCRIPTION
### Context

We'd like to communicate changes that we're making to vendors. To that end, we're being more deliberate in deploying by manually deploying to production (https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training-tech-docs/pull/32).

### Changes proposed in this pull request

This adds a page with release notes. This should be updated before every deploy to production.

We'll start with 0.1 (the version that is currently deployed) and work towards 0.2 (the next version).

#### What to include in the release notes

See the README.

### Guidance to review

Here's what it looks like:

<img width="1244" alt="Screenshot 2019-09-10 at 14 28 42" src="https://user-images.githubusercontent.com/233676/64617987-52acda80-d3d7-11e9-89ab-346143ed5551.png">

- Do the rules about what to include and not to include make sense?
- Do the words I've written make sense?
- Have I missed changes since the last deploy? ([here's the changelog I worked off](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training-tech-docs/compare/deploy-to-production...master))
- Does the release numbering make sense?

### Link to Trello card

[900 - Set up a versioned release process for the Tech Docs app](https://trello.com/c/n4Z0AukL/900-set-up-a-versioned-release-process-for-the-tech-docs-app)
