### PR TITLE
Reduce application Id to 10 characters

### DIFF
--- a/lib/application.json
+++ b/lib/application.json
@@ -1,9 +1,8 @@
 {
-  "id": "aa546741-b54a-403c-a67a-7f5aec1939d1",
+  "id": "11fc0d3b2f",
   "status": "open",
   "personal_statement": "Since retiring from the Police Service in 2007...",
   "candidate": {
-    "id": "a0afe017-ea18-491d-9bda-16037102e1dd",
     "first_name": "Boris",
     "last_name": "Brown",
     "date_of_birth": "1980-09-13",

--- a/lib/application_json.rb
+++ b/lib/application_json.rb
@@ -22,8 +22,8 @@ module ApplicationJson
     [
       {
         name: 'id',
-        type: 'uuid',
-        description: 'The unique ID of this application'
+        type: 'string',
+        description: 'The unique ID of this application - this is limited to 10 characters'
       },
       {
         name: 'status',
@@ -110,11 +110,6 @@ module ApplicationJson
 
   def candidate_attributes
     [
-      {
-        name: 'id',
-        type: 'uuid',
-        description: 'The unique ID of this candidate'
-      },
       {
         name: 'first_name',
         type: 'string',

--- a/source/amend-an-offer.html.md.erb
+++ b/source/amend-an-offer.html.md.erb
@@ -12,7 +12,7 @@ PATCH /applications/:id/offer
 ## Example request
 
 ```
-PATCH /applications/aa546741-b54a-403c-a67a-7f5aec1939d1/offer
+PATCH /applications/11fc0d3b2f/offer
 ```
 
 It's possible to amend one or all of the fields of an offer using this method.

--- a/source/make-an-offer.html.md.erb
+++ b/source/make-an-offer.html.md.erb
@@ -12,7 +12,7 @@ POST /applications/:id/offer
 ## Example request
 
 ```
-POST /applications/aa546741-b54a-403c-a67a-7f5aec1939d1/offer
+POST /applications/11fc0d3b2f/offer
 ```
 
 Request body:

--- a/source/reject-an-application.html.md.erb
+++ b/source/reject-an-application.html.md.erb
@@ -12,7 +12,7 @@ POST /applications/:id/rejection
 ## Example request
 
 ```
-POST /applications/aa546741-b54a-403c-a67a-7f5aec1939d1/rejection
+POST /applications/11fc0d3b2f/rejection
 ```
 
 Request body:

--- a/source/retrieve-a_single-application.html.md.erb
+++ b/source/retrieve-a_single-application.html.md.erb
@@ -13,7 +13,7 @@ Used to retrieve information about a single application.
 
 ## Example request
 ```
-GET /applications/aa546741-b54a-403c-a67a-7f5aec1939d1
+GET /applications/11fc0d3b2f
 ```
 ## Example response
 

--- a/spec/application_json_spec.rb
+++ b/spec/application_json_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe ApplicationJson do
   ].freeze
 
   CANDIDATE_FIELDS = %w[
-    id first_name last_name date_of_birth nationality
+    first_name last_name date_of_birth nationality
     uk_residency_status disability disability_hesa_code
   ].freeze
 


### PR DESCRIPTION
### Context

Feedback from vendors have highlighted that they currently cannot handle application ids that are larger than 10 characters.

### Changes proposed in this pull request
Update the vendor api documentation to show that application id is a unique string of 10 characters.
Update the vendor api documentation to remove id from the candidate resource as providers do not require that information.

### Guidance to review
Check the api documentation to ensure that the application id information is correct.

### Link to Trello card
[905 - Reduce uuid to 10 characters](https://trello.com/c/NFOYC3O9/905-reduce-uuid-to-10-characters)
