### PR TITLE
Make the logo link to the homepage of the docs

### DIFF
--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -4,7 +4,7 @@ host: apply-for-postgraduate-teacher-training-tech-docs.cloudapps.digital
 # Header-related options
 show_govuk_logo: true
 service_name: Apply for postgraduate teacher training
-service_link: https://apply-for-postgraduate-teacher-training.education.gov.uk
+service_link: /
 phase: Prototype
 
 # Links to show on right-hand-side of header


### PR DESCRIPTION
### Context

We currently link to a non-existing service domain.

### Changes proposed in this pull request

Link to the homepage of the docs.

### Guidance to review

Check that it works.

### Release notes

- [x] [If needed](/README.md#release-notes), the [release notes](/source/release-notes.html.md) have been updated

### Link to Trello card

[902 - Quick review of existing API](https://trello.com/c/oxb09wa8/902-quick-review-of-existing-api)
