### PR TITLE
Prevent the documentation from being indexed in search engines

### DIFF
--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -32,7 +32,7 @@ collapsible_nav: true
 max_toc_heading_level: 6
 
 # Prevent robots from indexing (e.g. whilst in development)
-prevent_indexing: false
+prevent_indexing: true
 
 show_contribution_banner: true
 github_repo: DFE-Digital/apply-for-postgraduate-teacher-training-tech-docs


### PR DESCRIPTION
### Context

Currently, search engines like Google are allowed to index this site. This is a prototype, so we don't want this indexed as yet.

### Changes proposed in this pull request

Turn on the `prevent_indexing` flag, which will [add the necessary meta tags to the pages](https://tdt-documentation.london.cloudapps.digital/configuration-options.html#prevent-indexing).

### Guidance to review

Check that the `noindex` metatags appear on the pages.

### Release notes

- [x] [If needed](/README.md#release-notes), the [release notes](/source/release-notes.html.md) have been updated

### Link to Trello card

[902 - Quick review of existing API](https://trello.com/c/oxb09wa8/902-quick-review-of-existing-api)