### PR TITLE
Fix example request URL for applications endpoint

### DIFF
--- a/source/retrieve-many-applications.html.md.erb
+++ b/source/retrieve-many-applications.html.md.erb
@@ -12,7 +12,7 @@ GET /applications
 ## Example request
 
 ```
-GET /applications/:id?since=2018-10-01T10:00:00Z
+GET /applications?since=2018-10-01T10:00:00Z
 ```
 
 ## Query parameters


### PR DESCRIPTION
### Context

This `:id` doesn't belong in the URL.

### Changes proposed in this pull request

Fix the URL.

### Link to Trello card

[902 - Quick review of existing API](https://trello.com/c/oxb09wa8/902-quick-review-of-existing-api)
