### PR TITLE
Remove fields from Candidate resource

### DIFF
--- a/lib/application.json
+++ b/lib/application.json
@@ -3,13 +3,9 @@
   "status": "open",
   "personal_statement": "Since retiring from the Police Service in 2007...",
   "candidate": {
-    "first_name": "Boris",
-    "last_name": "Brown",
-    "date_of_birth": "1980-09-13",
-    "nationality": "GB",
-    "uk_residency_status": "UK Citizen",
-    "disability": "Dyslexia",
-    "disability_hesa_code": "51"
+    "full_name": "Boris Brown",
+    "nationality": ["GB", "DE"],
+    "uk_residency_status": "UK Citizen"
   },
   "contact_details": {
     "phone_number": "07944386555",

--- a/lib/application_json.rb
+++ b/lib/application_json.rb
@@ -111,39 +111,19 @@ module ApplicationJson
   def candidate_attributes
     [
       {
-        name: 'first_name',
+        name: 'full_name',
         type: 'string',
-        description: 'The candidate’s first name - this can be up to 60 characters'
-      },
-      {
-        name: 'last_name',
-        type: 'string',
-        description: 'The candidate’s last name - this can be up to 60 characters'
-      },
-      {
-        name: 'date_of_birth',
-        type: 'string',
-        description: 'The candidate’s date of birth in YYYY-MM-DD format'
+        description: 'The candidate’s full name - this can be up to 60 characters'
       },
       {
         name: 'nationality',
-        type: 'string',
-        description: 'The candidate’s nationality as an ISO 3166 country code'
+        type: 'array',
+        description: 'One or more ISO 3166 country codes'
       },
       {
         name: 'uk_residency_status',
         type: 'string',
         description: 'The candidate’s UK residency status, e.g. Citizen'
-      },
-      {
-        name: 'disability',
-        type: 'string',
-        description: 'The candidate’s disabilities in a sentence'
-      },
-      {
-        name: 'disability_hesa_code',
-        type: 'string',
-        description: 'The candidate’s disabilities expressed as a HESA code'
       }
     ]
   end

--- a/source/release-notes.html.md
+++ b/source/release-notes.html.md
@@ -5,6 +5,12 @@ weight: 200
 
 # Release notes
 
+### Unreleased
+
+- Remove first and last name from Candidate in favour of full name
+- Remove id from Candidate
+- Remove disability information from Candidate, as this is not collected via the application form
+
 ### Release 0.2 - 11 September 2019
 
 - Limit the number of [offer conditions](/make-an-offer/#attributes) to 20

--- a/spec/application_json_spec.rb
+++ b/spec/application_json_spec.rb
@@ -26,8 +26,8 @@ RSpec.describe ApplicationJson do
   ].freeze
 
   CANDIDATE_FIELDS = %w[
-    first_name last_name date_of_birth nationality
-    uk_residency_status disability disability_hesa_code
+    full_name nationality
+    uk_residency_status
   ].freeze
 
   CONTACT_DETAILS_FIELDS = %w[


### PR DESCRIPTION
### Context

This resource contained elements that we couldn't provide.

### Changes proposed in this pull request

- first_ and last_name are condensed into full_name
- disability is removed as we don't collect it
- id is removed as there is no need for clients to refer to this

### Guidance to review

Make sure the Candidate docs still read well and that we're not removing
anything we shouldn't

### Release notes

- [X] [If needed](/README.md#release-notes), the [release notes](/source/release-notes.html.md) have been updated

### Link to Trello card

[Remove attributes from Candidate API entity](https://trello.com/c/9vUPcAM6/908-remove-attributes-from-candidate-api-entity)