### PR TITLE
Update contact details resource to split address

### DIFF
--- a/lib/application.json
+++ b/lib/application.json
@@ -14,7 +14,9 @@
     "address_line2": "Dialstone Lane",
     "address_line3": "Stockport",
     "address_line4": "England",
-    "postcode": "SK2 6AA"
+    "postcode": "SK2 6AA",
+    "country": "GB"
+
   },
   "course": {
     "description": "Acorns Teaching School Alliance, Oxford Oakleaf Campus, Primary (salaried, full-time) PGCE, September 2020",

--- a/lib/application.json
+++ b/lib/application.json
@@ -10,7 +10,11 @@
   "contact_details": {
     "phone_number": "07944386555",
     "email": "boris.brown@racingdemon.net",
-    "address": "45 Dialstone Lane, Stockport, England SK2 6AA"
+    "address_line1": "45",
+    "address_line2": "Dialstone Lane",
+    "address_line3": "Stockport",
+    "address_line4": "England",
+    "postcode": "SK2 6AA"
   },
   "course": {
     "description": "Acorns Teaching School Alliance, Oxford Oakleaf Campus, Primary (salaried, full-time) PGCE, September 2020",

--- a/lib/application_json.rb
+++ b/lib/application_json.rb
@@ -135,19 +135,39 @@ module ApplicationJson
   def contact_details_attributes
     [
       {
-        name: 'address',
+        name: 'address_line1',
         type: 'string',
-        description: 'The candidate’s address'
+        description: 'The candidate’s address line 1 - this is limited to 50 characters'
+      },
+      {
+        name: 'address_line2',
+        type: 'string',
+        description: 'The candidate’s address line 2 - this is limited to 50 characters'
+      },
+      {
+        name: 'address_line3',
+        type: 'string',
+        description: 'The candidate’s address line 3 - this is limited to 50 characters'
+      },
+      {
+        name: 'address_line4',
+        type: 'string',
+        description: 'The candidate’s address line 4 - this is limited to 50 characters'
+      },
+      {
+        name: 'postcode',
+        type: 'string',
+        description: 'The candidate’s postcode - this is limited to 8 characters'
       },
       {
         name: 'email',
         type: 'string',
-        description: 'The candidate’s email address'
+        description: 'The candidate’s email address - this is limited to 100 characters'
       },
       {
         name: 'phone_number',
         type: 'string',
-        description: 'The candidate’s phone number'
+        description: 'The candidate’s phone number - this is limited to 18 characters'
       }
     ]
   end

--- a/lib/application_json.rb
+++ b/lib/application_json.rb
@@ -160,6 +160,11 @@ module ApplicationJson
         description: 'The candidate’s postcode - this is limited to 8 characters'
       },
       {
+        name: 'country',
+        type: 'string',
+        description: 'The candidate’s country - ISO 3166 country code'
+      },
+      {
         name: 'email',
         type: 'string',
         description: 'The candidate’s email address - this is limited to 100 characters'

--- a/source/release-notes.html.md
+++ b/source/release-notes.html.md
@@ -11,6 +11,7 @@ weight: 200
 - Remove id from Candidate
 - Remove disability information from Candidate, as this is not collected via the application form
 - Rename the [rejection endpoint](/reject-an-application)
+- Update Contact Details resource to split address into separate fields
 
 ### Release 0.2 - 11 September 2019
 

--- a/spec/application_json_spec.rb
+++ b/spec/application_json_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe ApplicationJson do
   ].freeze
 
   CONTACT_DETAILS_FIELDS = %w[
-    phone_number address_line1 address_line2 address_line3 address_line4 postcode email
+    phone_number address_line1 address_line2 address_line3 address_line4 postcode country email
   ].freeze
 
   COURSE_FIELDS = %w[

--- a/spec/application_json_spec.rb
+++ b/spec/application_json_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe ApplicationJson do
   ].freeze
 
   CONTACT_DETAILS_FIELDS = %w[
-    phone_number address email
+    phone_number address_line1 address_line2 address_line3 address_line4 postcode email
   ].freeze
 
   COURSE_FIELDS = %w[


### PR DESCRIPTION
### Context
Currently, UCAS provide separate values for address lines 1 to 4, postcode and country code, and they are doing the same in their API. This is largely a DFE/HESA requirement 

### Changes proposed in this pull request
Update contact details resource to split the address field into:
- `address_line1`
- `address_line2`
- `address_line3`
- `address_line4`
- `postcode`
- `country`

![image](https://user-images.githubusercontent.com/47318392/64708902-46934c80-d4ad-11e9-882b-aff26a3cc95a.png)

### Guidance to review
Check the contact details resource on the resource and attributes page to ensure the address changes make sense.

### Release notes

- [x] [If needed](/README.md#release-notes), the [release notes](/source/release-notes.html.md) have been updated

### Link to Trello card

[670 - Model candidate addresses](https://trello.com/c/r2IFt1uG/670-figure-out-how-we-will-model-candidate-addresses)
