### PR TITLE
Remove description from course resource

### DIFF
--- a/lib/application.json
+++ b/lib/application.json
@@ -21,7 +21,6 @@
 
   },
   "course": {
-    "description": "Acorns Teaching School Alliance, Oxford Oakleaf Campus, Primary (salaried, full-time) PGCE, September 2020",
     "start_date": "2020-09-10",
     "provider_ucas_code": "2FR",
     "course_ucas_code": "3CVK",

--- a/lib/application_json.rb
+++ b/lib/application_json.rb
@@ -207,13 +207,6 @@ module ApplicationJson
   def course_attributes
     [
       {
-        name: 'description',
-        type: 'string',
-        description: 'A plain text description of the course, composed of
-          English translations of the provider UCAS code, the course UCAS code,
-          the location UCAS code, and the start date'
-      },
-      {
         name: 'start_date',
         type: 'string',
         description: 'The course’s start date in YYYY-MM-DD format'

--- a/source/release-notes.html.md
+++ b/source/release-notes.html.md
@@ -8,7 +8,13 @@ weight: 200
 ### Release 0.3 - 16 September 2019
 
 Changes to the data:
-
+- Remove first and last name from Candidate in favour of full name
+- Remove id from Candidate
+- Remove disability information from Candidate, as this is not collected via the application form
+- Remove functionality to amend an offer
+- Rename the [rejection endpoint](/reject-an-application)
+- Update Contact Details resource to split address into separate fields
+- Remove description from course resource
 - Add first name, last name and date of birth for Candidate
 
 ### Release 0.2 - 11 September 2019

--- a/spec/application_json_spec.rb
+++ b/spec/application_json_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe ApplicationJson do
   ].freeze
 
   COURSE_FIELDS = %w[
-    description provider_ucas_code course_ucas_code location_ucas_code
+    provider_ucas_code course_ucas_code location_ucas_code
     start_date
   ].freeze
 


### PR DESCRIPTION
### Context

We are currently providing human readable versions of the `UCAS  provider code`, `UCAS course code` and `UCAS location code`. 
Currently the FIND api constructs the course description from `study_mode`, `program_type` and `qualification`. 
The course description may not be needed as vendors may have a UCAS information already. 

### Changes proposed in this pull request

Remove the description from the course resource. 
Would like to discuss this.

### Guidance to review

Check the course resource and specs to ensure the description has been removed.
Would also like to discuss whether description should be provided by the vendor api or
if the api should construct the course description like the FIND api using the `study_mode`, `program_type` and `qualification`. 

### Release notes
- [x] [If needed](/README.md#release-notes), the [release notes](/source/release-notes.html.md) have been updated

### Link to Trello card
[690 - Update course description](https://trello.com/c/Yt95CNPy/690-split-course-description-attribute-within-techdocs)
