### PR TITLE
Rename org attribute to organisation for work experience resource

### DIFF
--- a/lib/application.json
+++ b/lib/application.json
@@ -37,7 +37,7 @@
     "equivalency_details": null
   }],
   "work_experiences": [{
-    "org": "Cheadle Hulme High School",
+    "organisation_name": "Cheadle Hulme High School",
     "start_date": "2018-05-01",
     "end_date": "2019-04-01",
     "role": "Whole School Literacy Specialist",

--- a/lib/application_json.rb
+++ b/lib/application_json.rb
@@ -285,7 +285,7 @@ module ApplicationJson
   def work_experience_attributes
     [
       {
-        name: 'org',
+        name: 'organisation_name',
         type: 'string',
         description: 'The name of the employer (company or individual)'
       },

--- a/source/release-notes.html.md
+++ b/source/release-notes.html.md
@@ -8,9 +8,13 @@ weight: 200
 ### Unreleased
 
 Changes to the data:
-- Remove date from reject endpoint
-- Update Usage scenarios to match reject endpoint
 
+- Remove date from reject endpoint
+- Rename the `org` attribute to `organisation_name` for the Work Experience resource
+
+Additional changes:
+
+- Update Usage scenarios to match reject endpoint
 
 ### Release 0.3 - 16 September 2019
 

--- a/spec/application_json_spec.rb
+++ b/spec/application_json_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe ApplicationJson do
   ].freeze
 
   WORK_EXPERIENCE_FIELDS = %w[
-    org start_date end_date role description
+    organisation_name start_date end_date role description
   ].freeze
 
   REFERENCE_FIELDS = %w[


### PR DESCRIPTION
### Context

We used an abbreviation for `organisation` which is something we would like to avoid doing for consistency.

### Changes proposed in this pull request

This PR renames the `org` attribute of the Work Experience resource to `organisation`.

### Guidance to review

Just a quick double check that this is the only place that `organisation` is used.

### Release notes

- [x] [If needed](/README.md#release-notes), the [release notes](/source/release-notes.html.md) have been updated

### Link to Trello card

[955 - Small Tech docs fix: Change org resource](https://trello.com/c/AfC2LAR6/955-small-tech-docs-fix-change-org-resource)
