### PR TITLE
942 correct api docs inconsistencies around rejection

### DIFF
--- a/lib/application.json
+++ b/lib/application.json
@@ -62,8 +62,7 @@
     "date": "2019-01-30T10:41:21Z"
   },
   "rejection": {
-    "reason": "Does not meet minimum GCSE requirements",
-    "date": "2019-01-30T10:41:21Z"
+    "reason": "Does not meet minimum GCSE requirements"
   },
   "submitted_at": "2019-06-13T10:44:31Z",
   "updated_at": "2019-06-13T10:44:31Z"

--- a/lib/application_json.rb
+++ b/lib/application_json.rb
@@ -398,11 +398,6 @@ module ApplicationJson
         name: 'reason',
         type: 'string',
         description: 'The reason for rejection'
-      },
-      {
-        name: 'date',
-        type: 'string',
-        description: 'The date on which the rejection was issued in YYYY-MM-DD format'
       }
     ]
   end

--- a/source/release-notes.html.md
+++ b/source/release-notes.html.md
@@ -5,6 +5,13 @@ weight: 200
 
 # Release notes
 
+### Unreleased
+
+Changes to the data:
+- Remove date from reject endpoint
+- Update Usage scenarios to match reject endpoint
+
+
 ### Release 0.3 - 16 September 2019
 
 Changes to the data:

--- a/source/usage-scenarios.html.md.erb
+++ b/source/usage-scenarios.html.md.erb
@@ -76,7 +76,7 @@ POST /applications/11fc0d3b2f/confirm-enrolment
 ### 1. The provider reviews the form and rejects the candidate without an interview
 
 ```
-POST /applications/11fc0d3b2f/rejection
+POST /applications/11fc0d3b2f/reject
 ```
 
 ```json

--- a/spec/application_json_spec.rb
+++ b/spec/application_json_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe ApplicationJson do
   ].freeze
 
   REJECTION_FIELDS = %w[
-    reason date
+    reason
   ].freeze
 
   describe '#single_application_json' do


### PR DESCRIPTION
### Context

Inconsistencies around the `reject` endpoint was found where the usage scenarios page uses a different endpoint `rejection`. 
This PR aims to address this. 

### Changes proposed in this pull request
Before
<img width="835" alt="Screenshot 2019-09-17 at 12 14 55" src="https://user-images.githubusercontent.com/47318392/65037070-c9505780-d944-11e9-954f-f3a59ceb61d7.png">

After
<img width="874" alt="Screenshot 2019-09-17 at 12 04 32" src="https://user-images.githubusercontent.com/47318392/65036734-0405c000-d944-11e9-89ed-a708c2f034ed.png">

- Update usage scenario page to use correct reject endpoint
- Remove date from reject endpoint

### Guidance to review

- Run test suite to ensure date has been removed from the reject endpoint correctly.
- Check the usage scenarios page to ensure that the `reject` endpoint is used instead of `rejection`.
### Release notes

- [ ] [If needed](/README.md#release-notes), the [release notes](/source/release-notes.html.md) have been updated

### Link to Trello card

[942 - Correct api docs around reject application inconsistencies](https://trello.com/c/TivTbOcQ/942-correct-api-docs-inconsistencies-around-rejection)
