### PR TITLE
968 update api docs to limit the number of nationalities to 2

### DIFF
--- a/lib/application_json.rb
+++ b/lib/application_json.rb
@@ -140,8 +140,8 @@ module ApplicationJson
       },
       {
         name: 'nationality',
-        type: 'array',
-        description: 'One or more ISO 3166 country codes'
+        type: 'array[2]',
+        description: 'ISO 3166 country codes - limited to 2'
       },
       {
         name: 'uk_residency_status',

--- a/source/release-notes.html.md
+++ b/source/release-notes.html.md
@@ -11,6 +11,7 @@ Changes to the data:
 
 - Remove date from reject endpoint
 - Rename the `org` attribute to `organisation_name` for the Work Experience resource
+- Limit candidates to only 2 nationalities
 
 Additional changes:
 


### PR DESCRIPTION
### Context

Currently the prototype limits the number of nationalities, and many downstream APIs do that too.
The api documentation should specify that we are limiting candidate resource to only two nationalities.

### Changes proposed in this pull request
Before
<img width="775" alt="Screenshot 2019-09-17 at 12 36 22" src="https://user-images.githubusercontent.com/47318392/65038874-d66f4580-d948-11e9-9c0d-d12ff981af21.png">

After
<img width="770" alt="Screenshot 2019-09-17 at 12 39 01" src="https://user-images.githubusercontent.com/47318392/65038880-dbcc9000-d948-11e9-8484-5660c4a0c131.png">
- Update resources and attributes page to reflect that the candidate resource is limited to 2 nationalities. 

### Guidance to review

Check the `resources and their attributes` page to ensure the candidate resource is correctly reflected.

### Release notes

- [x] [If needed](/README.md#release-notes), the [release notes](/source/release-notes.html.md) have been updated

### Link to Trello card

[968 - Update api docs to limit candidates to 2 nationalities](https://trello.com/c/VhRAqWSU/968-update-api-docs-to-limit-the-number-of-nationalities-to-2)
