### PR TITLE
Add an "order" parameter to /applications

### DIFF
--- a/lib/application_json.rb
+++ b/lib/application_json.rb
@@ -113,6 +113,12 @@ module ApplicationJson
         type: 'string',
         description: 'Optional. Include only applications changed or created on
         or since a date and time. Times should be in ISO 8601 format.'
+      },
+      {
+        name: 'order',
+        type: 'string',
+        description: 'Optional. Specify how the returned applications are to be
+        sorted: "newest_first" or "oldest_first". Defaults to "newest_first".'
       }
     ]
   end

--- a/source/openapi-spec.yml
+++ b/source/openapi-spec.yml
@@ -28,17 +28,17 @@ paths:
                     $ref: "#/components/schemas/Application"
   /applications:
     get:
-      summary: Retrieve many applications
+      summary: Retrieve many applications. Applications are returned in the order they were changed or created.
       parameters:
         - name: since
-          description: Optional. Include only applications changed or created on or since a date and time. Times should be in ISO 8601 format.
+          description: Include only applications changed or created on or since a date and time. Times should be in ISO 8601 format.
           in: query
           required: true
           schema:
             type: string
             format: date-time
         - name: order
-          description: If missing, defaults to newest_first
+          description: Specify how the returned applications are to be sorted. If missing, defaults to newest_first
           in: query
           schema:
             type: string

--- a/source/release-notes.html.md
+++ b/source/release-notes.html.md
@@ -13,6 +13,10 @@ Changes to the data:
 - Rename the `org` attribute to `organisation_name` for the Work Experience resource
 - Limit candidates to only 2 nationalities
 
+Changes to functionality:
+
+- Support an `order` parameter when [retrieving many applications](/retrieve-many-applications)
+
 Additional changes:
 
 - Clarify the endpoint for rejecting an application in usage scenarios
@@ -22,6 +26,7 @@ Additional changes:
 ### Release 0.3 - 16 September 2019
 
 Changes to the data:
+
 - Remove first and last name from Candidate in favour of full name
 - Remove id from Candidate
 - Remove disability information from Candidate, as this is not collected via the application form

--- a/source/retrieve-many-applications.html.md.erb
+++ b/source/retrieve-many-applications.html.md.erb
@@ -5,6 +5,8 @@ weight: 20
 
 # Retrieve many applications
 
+Applications are returned in the order they were changed or created.
+
 ```
 GET /applications
 ```

--- a/spec/application_json_spec.rb
+++ b/spec/application_json_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe ApplicationJson do
   ].freeze
 
   APPLICATIONS_PARAMS = %w[
-    since
+    since order
   ].freeze
 
   CANDIDATE_FIELDS = %w[


### PR DESCRIPTION
Specify the default behaviour when returning applications (reverse date order) and provide an override.

Not added to the example API call as it's optional.

### Context

Tribal asked about the ordering behaviour and also had a need to reverse it.

### Changes proposed in this pull request

Update the docs

### Guidance to review

How could someone else check this work? Which parts do you want more feedback on?

### Release notes

- [X] [If needed](/README.md#release-notes), the [release notes](/source/release-notes.html.md) have been updated

### Link to Trello card

https://trello.com/c/YppSFdBh/965-specify-ordering-for-the-applications-endpoint
