### PR TITLE
Update applications timestamp to correct format in usage scenarios

### DIFF
--- a/source/release-notes.html.md
+++ b/source/release-notes.html.md
@@ -14,7 +14,8 @@ Changes to the data:
 
 Additional changes:
 
-- Update Usage scenarios to match reject endpoint
+- Clarify the endpoint for rejecting an application in usage scenarios
+- Clarify the timestamp format for retrieving applications in usage scenarios
 
 ### Release 0.3 - 16 September 2019
 

--- a/source/usage-scenarios.html.md.erb
+++ b/source/usage-scenarios.html.md.erb
@@ -15,7 +15,7 @@ At the beginning of each scenario, a candidate has completed an application for 
 The provider has authenticated to your system and begins their work by retrieving all the applications since a given date. Your system issues the following request on their behalf:
 
 ```
-GET /applications?since=2019-01-10
+GET /applications?since=2018-10-01T10:00:00Z
 ```
 
 This returns a list of <%= link_to_resource_definition('Application') %>s:


### PR DESCRIPTION
### Context

The format of the timestamp used for getting applications in `Usage scenarios` is incorrect and doesn't match the format in `Retrieve many applications`.

### Changes proposed in this pull request

This PR updates the applications timestamp to the same format as it is in `Retrieve many applications`.

### Release notes

- [x] [If needed](/README.md#release-notes), the [release notes](/source/release-notes.html.md) have been updated

### Link to Trello card

[964 - Timestamp on /applications in usage scenario is misformatted](https://trello.com/c/vMU99D0M/964-timestamp-on-applications-in-usage-scenario-is-misformatted)
