### PR TITLE
Iterate API calls and methods to be more aligned to standards

### DIFF
--- a/lib/application.json
+++ b/lib/application.json
@@ -1,69 +1,71 @@
 {
   "id": "11fc0d3b2f",
-  "status": "application_complete",
-  "personal_statement": "Since retiring from the Police Service in 2007...",
-  "candidate": {
-    "first_name": "Boris",
-    "last_name": "Brown",
-    "date_of_birth": "1985-02-02",
-    "nationality": ["GB", "DE"],
-    "uk_residency_status": "UK Citizen"
-  },
-  "contact_details": {
-    "phone_number": "07944386555",
-    "email": "boris.brown@racingdemon.net",
-    "address_line1": "45",
-    "address_line2": "Dialstone Lane",
-    "address_line3": "Stockport",
-    "address_line4": "England",
-    "postcode": "SK2 6AA",
-    "country": "GB"
-
-  },
-  "course": {
-    "start_date": "2020-09-10",
-    "provider_ucas_code": "2FR",
-    "course_ucas_code": "3CVK",
-    "location_ucas_code": "K"
-  },
-  "qualifications": [{
-    "type": "BA",
-    "subject": "History and Politics",
-    "result": "2:1",
-    "award_year": "1992",
-    "place_of_study": "University of Huddersfield",
-    "awarding_body_name": null,
-    "awarding_body_country": "GB",
-    "equivalency_details": null
-  }],
-  "work_experiences": [{
-    "organisation_name": "Cheadle Hulme High School",
-    "start_date": "2018-05-01",
-    "end_date": "2019-04-01",
-    "role": "Whole School Literacy Specialist",
-    "description": "I lead, develop and enhance the literacy teaching practice of others..."
-  }],
-  "references": [{
-    "type": "school_senior_leadership",
-    "reason_for_character_reference": null,
-    "email": "julia@school.ac.uk",
-    "name": "Julia Wild",
-    "relationship": "Julia was my mentor at Cheadle Hulme High",
-    "content": "Boris is committed to the profession of teaching..."
-  }],
-  "offer": {
-    "conditions": [
-      "Completion of subject knowledge enhancement",
-      "Completion of professional skills test"
-    ]
-  },
-  "withdrawal": {
-    "reason": "Candidate is unwell",
-    "date": "2019-01-30T10:41:21Z"
-  },
-  "rejection": {
-    "reason": "Does not meet minimum GCSE requirements"
-  },
-  "submitted_at": "2019-06-13T10:44:31Z",
-  "updated_at": "2019-06-13T10:44:31Z"
+  "type": "application",
+  "attributes": {
+    "status": "application_complete",
+    "personal_statement": "Since retiring from the Police Service in 2007...",
+    "candidate": {
+      "first_name": "Boris",
+      "last_name": "Brown",
+      "date_of_birth": "1985-02-02",
+      "nationality": ["GB", "DE"],
+      "uk_residency_status": "UK Citizen"
+    },
+    "contact_details": {
+      "phone_number": "07944386555",
+      "email": "boris.brown@racingdemon.net",
+      "address_line1": "45",
+      "address_line2": "Dialstone Lane",
+      "address_line3": "Stockport",
+      "address_line4": "England",
+      "postcode": "SK2 6AA",
+      "country": "GB"
+    },
+    "course": {
+      "start_date": "2020-09-10",
+      "provider_ucas_code": "2FR",
+      "course_ucas_code": "3CVK",
+      "location_ucas_code": "K"
+    },
+    "qualifications": [{
+      "type": "BA",
+      "subject": "History and Politics",
+      "result": "2:1",
+      "award_year": "1992",
+      "place_of_study": "University of Huddersfield",
+      "awarding_body_name": null,
+      "awarding_body_country": "GB",
+      "equivalency_details": null
+    }],
+    "work_experiences": [{
+      "organisation_name": "Cheadle Hulme High School",
+      "start_date": "2018-05-01",
+      "end_date": "2019-04-01",
+      "role": "Whole School Literacy Specialist",
+      "description": "I lead, develop and enhance the literacy teaching practice of others..."
+    }],
+    "references": [{
+      "type": "school_senior_leadership",
+      "reason_for_character_reference": null,
+      "email": "julia@school.ac.uk",
+      "name": "Julia Wild",
+      "relationship": "Julia was my mentor at Cheadle Hulme High",
+      "content": "Boris is committed to the profession of teaching..."
+    }],
+    "offer": {
+      "conditions": [
+        "Completion of subject knowledge enhancement",
+        "Completion of professional skills test"
+      ]
+    },
+    "withdrawal": {
+      "reason": "Candidate is unwell",
+      "date": "2019-01-30T10:41:21Z"
+    },
+    "rejection": {
+      "reason": "Does not meet minimum GCSE requirements"
+    },
+    "submitted_at": "2019-06-13T10:44:31Z",
+    "updated_at": "2019-06-13T10:44:31Z"
+  }
 }

--- a/lib/application_json.rb
+++ b/lib/application_json.rb
@@ -10,9 +10,9 @@ module ApplicationJson
 
   def applications_json
     JSON.pretty_generate(
-      [
+      data: [
         single_application,
-        single_application.merge("id" => SecureRandom.hex[0..10])
+        single_application.merge('id' => SecureRandom.hex[0..10])
       ]
     )
   end

--- a/lib/application_json.rb
+++ b/lib/application_json.rb
@@ -4,7 +4,7 @@ module ApplicationJson
 
   def single_application_json
     JSON.pretty_generate(
-      single_application
+      data: single_application
     )
   end
 
@@ -18,7 +18,9 @@ module ApplicationJson
   end
 
   def single_application
-    json_data.merge(
+    application = json_data.clone
+
+    application['attributes'] = application['attributes'].merge(
       'withdrawal' => nil,
       'rejection' => nil,
       'offer' => nil,
@@ -29,6 +31,8 @@ module ApplicationJson
       'references' => DUMMY_ARRAY_OF_OBJECTS,
       'qualifications' => DUMMY_ARRAY_OF_OBJECTS
     )
+
+    application
   end
 
   def application_attributes
@@ -39,67 +43,72 @@ module ApplicationJson
         description: 'The unique ID of this application - this is limited to 10 characters'
       },
       {
-        name: 'status',
+        name: 'type',
+        type: 'string',
+        description: 'The type of resource'
+      },
+      {
+        name: 'attributes.status',
         type: 'string',
         description: 'The status of this application'
       },
       {
-        name: 'personal_statement',
+        name: 'attributes.personal_statement',
         type: 'string',
         description: 'The candidate’s personal statement - this can be up to 500 characters'
       },
       {
-        name: 'offer',
+        name: 'attributes.offer',
         type: link_to_resource_definition('Offer'),
         description: 'The offer on this application, if there is one'
       },
       {
-        name: 'rejection',
+        name: 'attributes.rejection',
         type: link_to_resource_definition('Rejection'),
         description: 'Rejection details, if applicable'
       },
       {
-        name: 'withdrawal',
+        name: 'attributes.withdrawal',
         type: link_to_resource_definition('Withdrawal'),
         description: 'Application withdrawal details, if applicable'
       },
       {
-        name: 'candidate',
+        name: 'attributes.candidate',
         type: link_to_resource_definition('Candidate'),
         description: 'Candidate details'
       },
       {
-        name: 'contact_details',
+        name: 'attributes.contact_details',
         type: link_to_resource_definition('Contact details'),
         description: 'Contact details'
       },
       {
-        name: 'course',
+        name: 'attributes.course',
         type: link_to_resource_definition('Course'),
         description: 'Course details'
       },
       {
-        name: 'work_experiences',
+        name: 'attributes.work_experiences',
         type: link_to_resource_definition('Work experience'),
         description: 'A list of work experiences'
       },
       {
-        name: 'references',
+        name: 'attributes.references',
         type: link_to_resource_definition('Reference'),
         description: 'Reference details'
       },
       {
-        name: 'qualifications',
+        name: 'attributes.qualifications',
         type: link_to_resource_definition('Qualification'),
         description: 'A list of qualifications'
       },
       {
-        name: 'submitted_at',
+        name: 'attributes.submitted_at',
         type: 'string',
         description: 'ISO 8601 date of submission, with time and timezone'
       },
       {
-        name: 'updated_at',
+        name: 'attributes.updated_at',
         type: 'string',
         description: 'ISO 8601 date of last change, with time and timezone'
       }
@@ -118,7 +127,7 @@ module ApplicationJson
   end
 
   def candidate_json
-    JSON.pretty_generate(json_data['candidate'])
+    JSON.pretty_generate(json_data['attributes']['candidate'])
   end
 
   def candidate_attributes
@@ -152,7 +161,7 @@ module ApplicationJson
   end
 
   def contact_details_json
-    JSON.pretty_generate(json_data['contact_details'])
+    JSON.pretty_generate(json_data['attributes']['contact_details'])
   end
 
   def contact_details_attributes
@@ -201,7 +210,7 @@ module ApplicationJson
   end
 
   def course_json
-    JSON.pretty_generate(json_data['course'])
+    JSON.pretty_generate(json_data['attributes']['course'])
   end
 
   def course_attributes
@@ -230,7 +239,7 @@ module ApplicationJson
   end
 
   def qualification_json
-    JSON.pretty_generate(json_data['qualifications'].first)
+    JSON.pretty_generate(json_data['attributes']['qualifications'].first)
   end
 
   def qualification_attributes
@@ -279,7 +288,7 @@ module ApplicationJson
   end
 
   def work_experience_json
-    JSON.pretty_generate(json_data['work_experiences'].first)
+    JSON.pretty_generate(json_data['attributes']['work_experiences'].first)
   end
 
   def work_experience_attributes
@@ -313,7 +322,7 @@ module ApplicationJson
   end
 
   def reference_json
-    JSON.pretty_generate(json_data['references'].first)
+    JSON.pretty_generate(json_data['attributes']['references'].first)
   end
 
   def reference_attributes
@@ -352,7 +361,7 @@ module ApplicationJson
   end
 
   def offer_json
-    JSON.pretty_generate(json_data['offer'])
+    JSON.pretty_generate(json_data['attributes']['offer'])
   end
 
   def offer_attributes
@@ -370,7 +379,7 @@ module ApplicationJson
   end
 
   def withdrawal_json
-    JSON.pretty_generate(json_data['withdrawal'])
+    JSON.pretty_generate(json_data['attributes']['withdrawal'])
   end
 
   def withdrawal_attributes
@@ -389,7 +398,7 @@ module ApplicationJson
   end
 
   def rejection_json
-    JSON.pretty_generate(json_data['rejection'])
+    JSON.pretty_generate(json_data['attributes']['rejection'])
   end
 
   def rejection_attributes

--- a/source/retrieve-many-applications.html.md.erb
+++ b/source/retrieve-many-applications.html.md.erb
@@ -24,7 +24,9 @@ GET /applications?since=2018-10-01T10:00:00Z
 **HTTP 200**
 
 ```json
-[ { Application }, { Application } ...  ]
+{
+  "data": [ { Application }, { Application } ... ]
+}
 ```
 
 ## Attributes

--- a/spec/application_json_spec.rb
+++ b/spec/application_json_spec.rb
@@ -128,6 +128,17 @@ RSpec.describe ApplicationJson do
     end
   end
 
+  describe '#applications_json' do
+    subject(:parsed_json) do
+      JSON.parse(including_class.applications_json)
+    end
+
+    it 'returns an array of objects' do
+      expect(parsed_json).to be_a Array
+      expect(parsed_json).to all be_a Hash
+    end
+  end
+
   describe '#application_attributes' do
     it 'contains an entry for all the relevant fields' do
       fields = including_class.application_attributes.map { |desc| desc[:name] }

--- a/spec/application_json_spec.rb
+++ b/spec/application_json_spec.rb
@@ -129,13 +129,25 @@ RSpec.describe ApplicationJson do
   end
 
   describe '#applications_json' do
-    subject(:parsed_json) do
-      JSON.parse(including_class.applications_json)
+    context 'within the JSON object' do
+      subject(:parsed_json) do
+        JSON.parse(including_class.applications_json)
+      end
+
+      it 'contains a data object' do
+        expect(parsed_json.keys).to contain_exactly('data')
+      end
     end
 
-    it 'returns an array of objects' do
-      expect(parsed_json).to be_a Array
-      expect(parsed_json).to all be_a Hash
+    context 'within the data object' do
+      subject(:parsed_data) do
+        JSON.parse(including_class.applications_json)['data']
+      end
+
+      it 'returns an array of objects' do
+        expect(parsed_data).to be_a Array
+        expect(parsed_data).to all be_a Hash
+      end
     end
   end
 


### PR DESCRIPTION
### Context

Currently, our API isn't using lessons learnt from standards like JSON:API,  hypermedia approaches and the [Government API standards](https://www.gov.uk/guidance/gds-api-technical-and-data-standards#use-json).

### Changes proposed in this pull request

WIP

### Guidance to review

WIP

### Release notes

- [ ] [If needed](/README.md#release-notes), the [release notes](/source/release-notes.html.md) have been updated

### Link to Trello card

[957 - Iterate API calls and methods to be more aligned to standards](https://trello.com/c/qPM2uTa9/957-iterate-api-calls-and-methods-to-be-more-aligned-to-standards)
