### PR TITLE
Add description of the API versioning

### DIFF
--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -87,3 +87,20 @@ and, assuming the user is still authorized to access the resources in
 question.
 
 _Last updated: <%= Date.today.strftime("%-d %B %Y") %>_
+
+### Versioning
+
+The version of the API is specified in the URL `/api/v{n}/`. For example: `/api/v1/`, `/api/v2/`, `/api/v3/`, ...
+
+When API changes in a way that is backwards-incompatible, a new version number of the API will be published.
+
+When a new version, for example `/api/v2`, is published, both the previous **v1** and the current **v2** versions will be supported.
+
+We, however, only support one version back, so if the **v3** is published, the **v1** will be discontinued.
+
+When non-breaking changes are made to the API, this will not result in a version bump.
+
+Information about deprecations (for instance attributes/endpoints that will be modified/removed) will be included in the API
+response through a "Warning" header.
+
+We will publish a changelog containing all breaking and non-breaking changes.

--- a/source/release-notes.html.md
+++ b/source/release-notes.html.md
@@ -17,6 +17,7 @@ Additional changes:
 
 - Clarify the endpoint for rejecting an application in usage scenarios
 - Clarify the timestamp format for retrieving applications in usage scenarios
+- Add description of the API versioning
 
 ### Release 0.3 - 16 September 2019
 


### PR DESCRIPTION
### Context

We need to add versioning to the API in order to evolve the API, without disruptions for the API clients. 

### Changes proposed in this pull request
To add the API version in the URL: `/api/v1/...`

### Link to Trello card

https://trello.com/c/cXJurUxl/961-add-information-about-versioning-to-tech-docs
