### PR TITLE
959 add information about error handling to the api docs

### DIFF
--- a/lib/application_json.rb
+++ b/lib/application_json.rb
@@ -402,6 +402,31 @@ module ApplicationJson
     ]
   end
 
+  def error_attributes
+    [
+      {
+        name: 'errors',
+        type: 'array',
+        description: 'Array containing multiple errors'
+      },
+      {
+        name: 'status',
+        type: 'string',
+        description: 'http status code for the error'
+      },
+      {
+        name: 'title',
+        type: 'string',
+        description: 'Generic information about the error'
+      },
+      {
+        name: 'detail',
+        type: 'string',
+        description: 'Information about this error specific to the occurrence'
+      },
+    ]
+  end
+
   def link_to_resource_definition(resource_name)
     slug = resource_name.downcase.gsub(' ', '-')
     link = "/resources-and-their-attributes##{slug}"

--- a/source/errors.html.md.erb
+++ b/source/errors.html.md.erb
@@ -1,0 +1,85 @@
+---
+title: Errors
+weight: 80
+---
+
+# Errors
+
+This page shows examples of error responses.
+
+Errors will be structured as such
+
+```
+{
+  "errors": [
+    {
+      "status": "422",
+      "title":  "Invalid Attribute",
+      "detail": "Volume does not, in fact, go to 11."
+    }
+  ]
+}
+```
+
+<%= partial 'partials/attribute_table', locals: { attributes: error_attributes } %>
+
+
+## Examples
+
+### No Authorisation
+
+If no authentication information provided with the request.
+
+```
+{
+  "errors": [
+    {
+      "status": "401",
+      "title":  "Unauthorized",
+      "detail": "Please use correct api token"
+    }
+  ]
+}
+```
+
+### Application not found
+
+If no Resource is found for a request.
+
+```
+GET /applications/:id
+```
+
+```
+{
+  "errors": [
+    {
+      "status": "404",
+      "title":  "Not Found",
+      "detail": "Application not found"
+    }
+  ]
+}
+```
+
+### Application in wrong state
+
+When an application is found, but is in the wrong state.
+
+```
+POST /applications/:id/offer
+```
+
+If the application found has been withdrawn by the candidate.
+
+```
+{
+  "errors": [
+    {
+      "status": "409",
+      "title":  "Conflict",
+      "detail": "You cannot submit an offer to application in withdrawn state"
+    }
+  ]
+}
+```

--- a/source/release-notes.html.md
+++ b/source/release-notes.html.md
@@ -17,6 +17,7 @@ Additional changes:
 
 - Clarify the endpoint for rejecting an application in usage scenarios
 - Clarify the timestamp format for retrieving applications in usage scenarios
+- Add Errors page to clarify error responses
 
 ### Release 0.3 - 16 September 2019
 


### PR DESCRIPTION
### Context

Vendors have requested documentation to clarify potential error responses from the api.

### Changes proposed in this pull request

- Add an Errors page to the documentation to outline the basic structure of errors and some examples of potential errors while using the api.

### Guidance to review

Check the Errors page to ensure that the documentation makes sense.

### Release notes

- [x ] [If needed](/README.md#release-notes), the [release notes](/source/release-notes.html.md) have been updated

### Link to Trello card

[959 - add information about error handling to the api docs](https://trello.com/c/HrYp2uiD/959-add-information-about-error-handling-to-the-api-docs)
