### PR TITLE
Start converting to API to OpenAPI

### DIFF
--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -36,3 +36,5 @@ prevent_indexing: true
 
 show_contribution_banner: true
 github_repo: DFE-Digital/apply-for-postgraduate-teacher-training-tech-docs
+
+api_path: ./source/openapi-spec.yml

--- a/source/openapi-spec.yml
+++ b/source/openapi-spec.yml
@@ -180,7 +180,7 @@ components:
           type: string
           description: The candidate’s email address
           maxLength: 100
-          example: boris.brown@racingdemon.net
+          example: boris.brown@example.com
         phone_number:
           type: string
           description: The candidate’s phone number

--- a/source/openapi-spec.yml
+++ b/source/openapi-spec.yml
@@ -25,7 +25,6 @@ paths:
                 type: object
                 properties:
                   data:
-                    type: object
                     $ref: "#/components/schemas/Application"
   /applications:
     get:

--- a/source/openapi-spec.yml
+++ b/source/openapi-spec.yml
@@ -79,40 +79,58 @@ components:
             - application
           example: application
         attributes:
-          type: object
-          properties:
-            status:
-              $ref: "#/components/schemas/status"
-            personal_statement:
-              $ref: "#/components/schemas/personal_statement"
-            candidate:
-              $ref: "#/components/schemas/candidate"
-            contact_details:
-              $ref: "#/components/schemas/contact_details"
-            course:
-              $ref: "#/components/schemas/course"
-            qualifications:
-              type: array
-              items:
-                $ref: "#/components/schemas/qualification"
-            work_experiences:
-              type: array
-              items:
-                $ref: "#/components/schemas/work_experience"
-            references:
-              type: array
-              items:
-                $ref: "#/components/schemas/reference"
-            offer:
-              $ref: "#/components/schemas/offer"
-            withdrawal:
-              $ref: "#/components/schemas/withdrawal"
-            rejection:
-              $ref: "#/components/schemas/rejection"
-            submitted_at:
-              $ref: "#/components/schemas/submitted_at"
-            updated_at:
-              $ref: "#/components/schemas/updated_at"
+          $ref: "#/components/schemas/ApplicationAttributes"
+
+    ApplicationAttributes:
+      type: object
+      properties:
+        status:
+          type: string
+          description: The status of this application
+          enum:
+            - accepted
+            - rejected
+          example: accepted
+        submitted_at:
+          type: string
+          format: date-time
+          description: ISO 8601 date of submission, with time and timezone
+          example: "2019-06-13T10:44:31Z"
+        updated_at:
+          type: string
+          format: date-time
+          description: ISO 8601 date of last change, with time and timezone
+          example: "2019-06-13T10:44:31Z"
+        personal_statement:
+          type: string
+          description: The candidate’s personal statement
+          maxLength: 500
+          example: "Since retiring from the Police Service in 2007..."
+        candidate:
+          $ref: "#/components/schemas/candidate"
+        contact_details:
+          $ref: "#/components/schemas/contact_details"
+        course:
+          $ref: "#/components/schemas/course"
+        qualifications:
+          type: array
+          items:
+            $ref: "#/components/schemas/qualification"
+        work_experiences:
+          type: array
+          items:
+            $ref: "#/components/schemas/work_experience"
+        references:
+          type: array
+          items:
+            $ref: "#/components/schemas/reference"
+        offer:
+          $ref: "#/components/schemas/offer"
+        withdrawal:
+          $ref: "#/components/schemas/withdrawal"
+        rejection:
+          $ref: "#/components/schemas/rejection"
+
     candidate:
       type: object
       properties:
@@ -216,11 +234,6 @@ components:
             maxLength: 255
           description: The conditions of the offer
           maxItems: 20
-    personal_statement:
-      type: string
-      description: The candidate’s personal statement
-      maxLength: 500
-      example: "Since retiring from the Police Service in 2007..."
     qualification:
       type: object
       properties:
@@ -297,23 +310,6 @@ components:
           format: date-time
           description: The date on which the rejection was issued
           example: "2019-09-18T15:33:49.216Z"
-    status:
-      type: string
-      description: The status of this application
-      enum:
-        - accepted
-        - rejected
-      example: accepted
-    submitted_at:
-      type: string
-      format: date-time
-      description: ISO 8601 date of submission, with time and timezone
-      example: "2019-06-13T10:44:31Z"
-    updated_at:
-      type: string
-      format: date-time
-      description: ISO 8601 date of last change, with time and timezone
-      example: "2019-06-13T10:44:31Z"
     withdrawal:
       type: object
       properties:

--- a/source/openapi-spec.yml
+++ b/source/openapi-spec.yml
@@ -1,0 +1,354 @@
+openapi: 3.0.0
+info:
+  version: 0.0.4
+  title: Apply API
+servers:
+  - url: "https://sandbox.azurewebsites.net/vendor-api/v1"
+paths:
+  "/applications/{application_id}":
+    get:
+      summary: Retrieve an application
+      parameters:
+        - name: application_id
+          in: path
+          required: true
+          description: The unique ID of this application
+          schema:
+            type: string
+            maxLength: 10
+      responses:
+        "200":
+          description: An application
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: object
+                    $ref: "#/components/schemas/Application"
+  /applications:
+    get:
+      summary: Retrieve many applications
+      parameters:
+        - name: since
+          description: Optional. Include only applications changed or created on or since a date and time. Times should be in ISO 8601 format.
+          in: query
+          required: true
+          schema:
+            type: string
+            format: date-time
+        - name: order
+          description: If missing, defaults to newest_first
+          in: query
+          schema:
+            type: string
+            default: newest_first
+            enum:
+              - newest_first
+              - oldest_first
+      responses:
+        "200":
+          description: An array of applications
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/Application"
+components:
+  schemas:
+    Application:
+      type: object
+      additionalProperties: false
+      required:
+        - id
+        - type
+        - attributes
+      properties:
+        id:
+          type: string
+          description: The unique ID of this application
+          maxLength: 10
+          example: 11fc0d3b2f
+        type:
+          type: string
+          enum:
+            - application
+          example: application
+        attributes:
+          type: object
+          properties:
+            status:
+              $ref: "#/components/schemas/status"
+            personal_statement:
+              $ref: "#/components/schemas/personal_statement"
+            candidate:
+              $ref: "#/components/schemas/candidate"
+            contact_details:
+              $ref: "#/components/schemas/contact_details"
+            course:
+              $ref: "#/components/schemas/course"
+            qualifications:
+              type: array
+              items:
+                $ref: "#/components/schemas/qualification"
+            work_experiences:
+              type: array
+              items:
+                $ref: "#/components/schemas/work_experience"
+            references:
+              type: array
+              items:
+                $ref: "#/components/schemas/reference"
+            offer:
+              $ref: "#/components/schemas/offer"
+            withdrawal:
+              $ref: "#/components/schemas/withdrawal"
+            rejection:
+              $ref: "#/components/schemas/rejection"
+            submitted_at:
+              $ref: "#/components/schemas/submitted_at"
+            updated_at:
+              $ref: "#/components/schemas/updated_at"
+    candidate:
+      type: object
+      properties:
+        first_name:
+          type: string
+          description: The candidate’s first name
+          maxLength: 60
+          example: Boris
+        last_name:
+          type: string
+          description: The candidate’s last name
+          example: Brown
+          maxLength: 60
+        date_of_birth:
+          type: string
+          format: date
+          description: The candidate’s date of birth
+          example: "1985-02-02"
+        nationality:
+          type: array
+          items:
+            type: string
+            pattern: "^[A-Z]{2}$"
+            example: NL
+          maxItems: 2
+          description: One or more ISO 3166 country codes
+        uk_residency_status:
+          type: string
+          description: "The candidate’s UK residency status, e.g. Citizen"
+          example: UK Citizen
+    contact_details:
+      type: object
+      properties:
+        address_line1:
+          type: string
+          description: The candidate’s address line 1
+          maxLength: 50
+          example: 45
+        address_line2:
+          type: string
+          description: The candidate’s address line 2
+          maxLength: 50
+          example: Dialstone Lane
+        address_line3:
+          type: string
+          description: The candidate’s address line 3
+          maxLength: 50
+          example: Stockport
+        address_line4:
+          type: string
+          description: The candidate’s address line 4
+          maxLength: 50
+          example: England
+        postcode:
+          type: string
+          description: The candidate’s postcode
+          maxLength: 8
+          example: SK2 6AA
+        country:
+          type: string
+          description: The candidate’s country - ISO 3166 country code
+          pattern: "^[A-Z]{2}$"
+          example: GB
+        email:
+          type: string
+          description: The candidate’s email address
+          maxLength: 100
+          example: boris.brown@racingdemon.net
+        phone_number:
+          type: string
+          description: The candidate’s phone number
+          maxLength: 18
+          example: 07944386555
+    course:
+      type: object
+      properties:
+        start_date:
+          type: string
+          format: date
+          description: The course’s start date
+          example: "2020-09-10"
+        provider_ucas_code:
+          type: string
+          description: The provider’s UCAS code
+          example: 2FR
+        course_ucas_code:
+          type: string
+          description: The course’s UCAS code
+          example: 3CVK
+        location_ucas_code:
+          type: string
+          description: The location’s UCAS code
+          example: K
+    offer:
+      type: object
+      properties:
+        conditions:
+          type: array
+          items:
+            type: string
+            maxLength: 255
+          description: The conditions of the offer
+          maxItems: 20
+    personal_statement:
+      type: string
+      description: The candidate’s personal statement
+      maxLength: 500
+      example: "Since retiring from the Police Service in 2007..."
+    qualification:
+      type: object
+      properties:
+        qualification_type:
+          type: string
+          description: The qualification awarded
+          example: BA
+        subject:
+          type: string
+          description: The subject studied
+          example: History and Politics
+        result:
+          type: string
+          description: The grade awarded
+          example: "2:1"
+        award_year:
+          type: string
+          description: The year the award was made
+          example: "1992"
+        place_of_study:
+          type: string
+          description: The place of study
+          example: University of Huddersfield
+        awarding_body_name:
+          type: string
+          description: "Optional. The awarding body’s name, e.g. AQA"
+        awarding_body_country:
+          type: string
+          description: The awarding body’s country as an ISO 3166 country code
+          example: GB
+        equivalency_details:
+          type: string
+          description: Optional. Details of equivalency, if this qualification was awarded overseas
+    reference:
+      type: object
+      properties:
+        reference_type:
+          type: string
+          description: The type of the reference
+          enum:
+            - academic
+            - professional
+            - school_senior_leadership
+            - character
+          example: school_senior_leadership
+        reason_for_character_reference:
+          type: string
+          description: "If this is a character reference, this field will contain the reason the candidate gave for not providing one of the other types"
+        email:
+          type: string
+          description: The referee’s email
+          example: julia@example.com
+        name:
+          type: string
+          description: The referee’s name
+          example: Julia Wild
+        relationship:
+          type: string
+          description: The referee’s relationship to the candidate
+          example: Julia was my mentor at Cheadle Hulme High
+        content:
+          type: string
+          description: "Optional. The reference content provided by the referee, once it is available"
+          example: Boris is committed to the profession of teaching...
+    rejection:
+      type: object
+      properties:
+        reason:
+          type: string
+          description: The reason for rejection
+          example: Does not meet minimum GCSE requirements
+        date:
+          type: string
+          format: date-time
+          description: The date on which the rejection was issued
+          example: "2019-09-18T15:33:49.216Z"
+    status:
+      type: string
+      description: The status of this application
+      enum:
+        - accepted
+        - rejected
+      example: accepted
+    submitted_at:
+      type: string
+      format: date-time
+      description: ISO 8601 date of submission, with time and timezone
+      example: "2019-06-13T10:44:31Z"
+    updated_at:
+      type: string
+      format: date-time
+      description: ISO 8601 date of last change, with time and timezone
+      example: "2019-06-13T10:44:31Z"
+    withdrawal:
+      type: object
+      properties:
+        reason:
+          type: string
+          description: Optional. The candidate’s reason for withdrawing
+          example: Candidate is unwell
+        date:
+          type: string
+          format: date-time
+          description: The date on which the withdrawal was received
+          example: "2019-09-18T15:33:49.216Z"
+    work_experience:
+      type: object
+      properties:
+        organisation_name:
+          type: string
+          description: The name of the employer (company or individual)
+          example: Cheadle Hulme High School
+        start_date:
+          type: string
+          format: date
+          description: The date employment began
+          example: "2020-09-10"
+        end_date:
+          type: string
+          format: date
+          description: "The date employment finished, if appropriate"
+          example: "2019-04-01"
+        role:
+          type: string
+          description: The position held by the candidate
+          example: Whole School Literacy Specialist
+        description:
+          type: string
+          description: A brief written description of the work involved
+          example: "I lead, develop and enhance the literacy teaching practice of others..."

--- a/source/openapi-spec.yml
+++ b/source/openapi-spec.yml
@@ -107,31 +107,31 @@ components:
           maxLength: 500
           example: "Since retiring from the Police Service in 2007..."
         candidate:
-          $ref: "#/components/schemas/candidate"
+          $ref: "#/components/schemas/Candidate"
         contact_details:
-          $ref: "#/components/schemas/contact_details"
+          $ref: "#/components/schemas/ContactDetails"
         course:
-          $ref: "#/components/schemas/course"
+          $ref: "#/components/schemas/Course"
         qualifications:
           type: array
           items:
-            $ref: "#/components/schemas/qualification"
+            $ref: "#/components/schemas/Qualification"
         work_experiences:
           type: array
           items:
-            $ref: "#/components/schemas/work_experience"
+            $ref: "#/components/schemas/WorkExperience"
         references:
           type: array
           items:
-            $ref: "#/components/schemas/reference"
+            $ref: "#/components/schemas/Reference"
         offer:
-          $ref: "#/components/schemas/offer"
+          $ref: "#/components/schemas/Offer"
         withdrawal:
-          $ref: "#/components/schemas/withdrawal"
+          $ref: "#/components/schemas/Withdrawal"
         rejection:
-          $ref: "#/components/schemas/rejection"
+          $ref: "#/components/schemas/Rejection"
 
-    candidate:
+    Candidate:
       type: object
       properties:
         first_name:
@@ -161,7 +161,7 @@ components:
           type: string
           description: "The candidate’s UK residency status, e.g. Citizen"
           example: UK Citizen
-    contact_details:
+    ContactDetails:
       type: object
       properties:
         address_line1:
@@ -204,7 +204,7 @@ components:
           description: The candidate’s phone number
           maxLength: 18
           example: 07944386555
-    course:
+    Course:
       type: object
       properties:
         start_date:
@@ -224,7 +224,7 @@ components:
           type: string
           description: The location’s UCAS code
           example: K
-    offer:
+    Offer:
       type: object
       properties:
         conditions:
@@ -234,7 +234,7 @@ components:
             maxLength: 255
           description: The conditions of the offer
           maxItems: 20
-    qualification:
+    Qualification:
       type: object
       properties:
         qualification_type:
@@ -267,7 +267,7 @@ components:
         equivalency_details:
           type: string
           description: Optional. Details of equivalency, if this qualification was awarded overseas
-    reference:
+    Reference:
       type: object
       properties:
         reference_type:
@@ -298,7 +298,7 @@ components:
           type: string
           description: "Optional. The reference content provided by the referee, once it is available"
           example: Boris is committed to the profession of teaching...
-    rejection:
+    Rejection:
       type: object
       properties:
         reason:
@@ -310,7 +310,7 @@ components:
           format: date-time
           description: The date on which the rejection was issued
           example: "2019-09-18T15:33:49.216Z"
-    withdrawal:
+    Withdrawal:
       type: object
       properties:
         reason:
@@ -322,7 +322,7 @@ components:
           format: date-time
           description: The date on which the withdrawal was received
           example: "2019-09-18T15:33:49.216Z"
-    work_experience:
+    WorkExperience:
       type: object
       properties:
         organisation_name:

--- a/source/openapi-spec.yml
+++ b/source/openapi-spec.yml
@@ -3,7 +3,7 @@ info:
   version: 0.0.4
   title: Apply API
 servers:
-  - url: "https://sandbox.azurewebsites.net/vendor-api/v1"
+  - url: "https://example.com/vendor-api/v1"
 paths:
   "/applications/{application_id}":
     get:

--- a/source/reference.html.md
+++ b/source/reference.html.md
@@ -1,0 +1,5 @@
+---
+title: API reference
+---
+
+api>

--- a/spec/open_api_spec.rb
+++ b/spec/open_api_spec.rb
@@ -1,0 +1,7 @@
+RSpec.describe "OpenAPI spec" do
+  document = Openapi3Parser.load_file("source/openapi-spec.yml")
+
+  it "is a valid OpenAPI spec" do
+    expect(document).to be_valid, document.errors.to_a.inspect
+  end
+end


### PR DESCRIPTION
### Context

We've decided to make a move towards OpenAPI:

- To make sure we don't make any mistakes in the API specification
- To be able to present the specification in a standard format to vendors — Ellucian explicitly requested it
- To make the docs machine-readable, to drive automated tests and act as a dummy implementation

### Changes proposed in this pull request

This PR adds an API reference page which uses the GOV.UK Tech Docs Template feature of creating documentation using an OpenAPI spec YAML file. Within the OpenAPI definition, two endpoints have been added to:

- retrieve an application
- retrieve many applications

Follow ups in the checklist: https://trello.com/c/mHL0Q44U/938-convert-tech-docs-to-openapi

### Guidance to review

- Has the two endpoints been correctly represented in the OpenAPI spec?

### Release notes

- [ ] [If needed](/README.md#release-notes), the [release notes](/source/release-notes.html.md) have been updated

### Link to Trello card

[938 - Convert tech docs to OpenAPI](https://trello.com/c/mHL0Q44U/938-convert-tech-docs-to-openapi)
