### PR TITLE
Pull in fix for bug in API docs that shows required attributes as optional 

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -1,5 +1,6 @@
 require 'govuk_tech_docs'
 require 'lib/application_json'
+require 'lib/govuk_tech_docs/api_reference/api_reference_extension.rb'
 
 helpers ApplicationJson
 

--- a/lib/govuk_tech_docs/api_reference/api_reference_extension.rb
+++ b/lib/govuk_tech_docs/api_reference/api_reference_extension.rb
@@ -1,0 +1,103 @@
+require 'erb'
+require 'openapi3_parser'
+require 'uri'
+require 'pry'
+
+# Use the local version of the OpenAPI renderer
+require 'lib/govuk_tech_docs/api_reference/api_reference_renderer'
+
+module GovukTechDocs
+  module ApiReference
+    class Extension < Middleman::Extension
+      expose_to_application api: :api
+
+      def initialize(app, options_hash = {}, &block)
+        super
+
+        @app = app
+        @config = @app.config[:tech_docs]
+
+        # If no api path then just return.
+        if @config['api_path'].to_s.empty?
+          @api_parser = false
+          return
+        end
+
+        # Is the api_path a url or path?
+        if uri?(@config['api_path'])
+          @api_parser = true
+          @document = Openapi3Parser.load_url(@config['api_path'])
+        elsif File.exist?(@config['api_path'])
+          # Load api file and set existence flag.
+          @api_parser = true
+          @document = Openapi3Parser.load_file(@config['api_path'])
+        else
+          @api_parser = false
+          raise 'Unable to load api path from tech-docs.yml'
+        end
+        @render = Renderer.new(@app, @document)
+      end
+
+      def uri?(string)
+        uri = URI.parse(string)
+        %w(http https).include?(uri.scheme)
+      rescue URI::BadURIError
+        false
+      rescue URI::InvalidURIError
+        false
+      end
+
+      def api(text)
+        if @api_parser == true
+
+          keywords = {
+            'api&gt;' => 'default',
+            'api_schema&gt;' => 'schema'
+          }
+
+          regexp = keywords.map { |k, _| Regexp.escape(k) }.join('|')
+
+          md = text.match(/^<p>(#{regexp})/)
+          if md
+            key = md.captures[0]
+            type = keywords[key]
+
+            text.gsub!(/#{Regexp.escape(key)}\s+?/, '')
+
+            # Strip paragraph tags from text
+            text = text.gsub(/<\/?[^>]*>/, '')
+            text = text.strip
+
+            if text == 'api&gt;'
+              @render.api_full(api_info, api_servers)
+            elsif type == 'default'
+              output = @render.path(text)
+              # Render any schemas referenced in the above path
+              output += @render.schemas_from_path(text)
+              output
+            else
+              @render.schema(text)
+            end
+
+          else
+            return text
+          end
+        else
+          text
+        end
+      end
+
+    private
+
+      def api_info
+        @document.info
+      end
+
+      def api_servers
+        @document.servers
+      end
+    end
+  end
+end
+
+::Middleman::Extensions.register(:api_reference, GovukTechDocs::ApiReference::Extension)

--- a/lib/govuk_tech_docs/api_reference/api_reference_renderer.rb
+++ b/lib/govuk_tech_docs/api_reference/api_reference_renderer.rb
@@ -1,0 +1,280 @@
+require 'erb'
+require 'json'
+
+module GovukTechDocs
+  module ApiReference
+    class Renderer
+      def initialize(app, document)
+        @app = app
+        @document = document
+
+        # Load template files
+        @template_api_full = get_renderer('api_reference_full.html.erb')
+        @template_path = get_renderer('path.html.erb')
+        @template_schema = get_renderer('schema.html.erb')
+        @template_operation = get_renderer('operation.html.erb')
+        @template_parameters = get_renderer('parameters.html.erb')
+        @template_responses = get_renderer('responses.html.erb')
+      end
+
+      def api_full(info, servers)
+        paths = ''
+        paths_data = @document.paths
+        paths_data.each do |path_data|
+          # For some reason paths.each returns an array of arrays [title, object]
+          # instead of an array of objects
+          text = path_data[0]
+          paths += path(text)
+        end
+        schemas = ''
+        schemas_data = @document.components.schemas
+        schemas_data.each do |schema_data|
+          text = schema_data[0]
+          schemas += schema(text)
+        end
+        @template_api_full.result(binding)
+      end
+
+      def path(text)
+        path = @document.paths[text]
+        id = text.parameterize
+        operations = operations(path, id)
+        @template_path.result(binding)
+      end
+
+      def schema(text)
+        schemas = ''
+        schemas_data = @document.components.schemas
+        schemas_data.each do |schema_data|
+          all_of = schema_data[1]["allOf"]
+          properties = []
+          if !all_of.blank?
+            all_of.each do |schema_nested|
+              schema_nested.properties.each do |property|
+                properties.push property
+              end
+            end
+          end
+
+          schema_data[1].properties.each do |property|
+            properties.push property
+          end
+
+          if schema_data[0] == text
+            title = schema_data[0]
+            schema = schema_data[1]
+            return @template_schema.result(binding)
+          end
+        end
+      end
+
+      def schemas_from_path(text)
+        path = @document.paths[text]
+        operations = get_operations(path)
+        # Get all referenced schemas
+        schemas = []
+        operations.compact.each_value do |operation|
+          responses = operation.responses
+          responses.each do |_rkey, response|
+            if response.content['application/json']
+              schema = response.content['application/json'].schema
+              schema_name = get_schema_name(schema.node_context.source_location.to_s)
+              if !schema_name.nil?
+                schemas.push schema_name
+              end
+              schemas.concat(schemas_from_schema(schema))
+            end
+          end
+        end
+        # Render all referenced schemas
+        output = ''
+        schemas.uniq.each do |schema_name|
+          output += schema(schema_name)
+        end
+        if !output.empty?
+          output.prepend('<h2 id="schemas">Schemas</h2>')
+        end
+        output
+      end
+
+      def schemas_from_schema(schema)
+        schemas = []
+        properties = []
+        schema.properties.each do |property|
+          properties.push property[1]
+        end
+        if schema.type == 'array'
+          properties.push schema.items
+        end
+        all_of = schema["allOf"]
+        if !all_of.blank?
+          all_of.each do |schema_nested|
+            schema_nested.properties.each do |property|
+              properties.push property[1]
+            end
+          end
+        end
+        properties.each do |property|
+          # Must be a schema be referenced by another schema
+          # And not a property of a schema
+          if property.node_context.referenced_by.to_s.include?('#/components/schemas') &&
+              !property.node_context.source_location.to_s.include?('/properties/')
+            schema_name = get_schema_name(property.node_context.source_location.to_s)
+          end
+          if !schema_name.nil?
+            schemas.push schema_name
+          end
+          # Check sub-properties for references
+          schemas.concat(schemas_from_schema(property))
+        end
+        schemas
+      end
+
+      def operations(path, path_id)
+        output = ''
+        operations = get_operations(path)
+        operations.compact.each do |key, operation|
+          id = "#{path_id}-#{key.parameterize}"
+          parameters = parameters(operation, id)
+          responses = responses(operation, id)
+          output += @template_operation.result(binding)
+        end
+        output
+      end
+
+      def parameters(operation, operation_id)
+        parameters = operation.parameters
+        id = "#{operation_id}-parameters"
+        output = @template_parameters.result(binding)
+        output
+      end
+
+      def responses(operation, operation_id)
+        responses = operation.responses
+        id = "#{operation_id}-responses"
+        output = @template_responses.result(binding)
+        output
+      end
+
+      def markdown(text)
+        if text
+          Tilt['markdown'].new(context: @app) { text }.render
+        end
+      end
+
+      def json_output(schema)
+        properties =  schema_properties(schema)
+        JSON.pretty_generate(properties)
+      end
+
+      def json_prettyprint(data)
+        JSON.pretty_generate(data)
+      end
+
+      def schema_properties(schema_data)
+        properties = Hash.new
+        if defined? schema_data.properties
+          schema_data.properties.each do |key, property|
+            properties[key] = property
+          end
+        end
+        properties.merge! get_all_of_hash(schema_data)
+        properties_hash = Hash.new
+        properties.each do |pkey, property|
+          if property.type == 'object'
+            properties_hash[pkey] = Hash.new
+            items = property.items
+            if !items.blank?
+              properties_hash[pkey] = schema_properties(items)
+            end
+            if !property.properties.blank?
+              properties_hash[pkey] = schema_properties(property)
+            end
+          elsif property.type == 'array'
+            properties_hash[pkey] = Array.new
+            items = property.items
+            if !items.blank?
+              properties_hash[pkey].push schema_properties(items)
+            end
+          else
+            properties_hash[pkey] = !property.example.nil? ? property.example : property.type
+          end
+        end
+
+        properties_hash
+      end
+
+    private
+
+      def get_all_of_array(schema)
+        properties = Array.new
+        if schema.is_a?(Array)
+          schema = schema[1]
+        end
+        if schema["allOf"]
+          all_of = schema["allOf"]
+        end
+        if !all_of.blank?
+          all_of.each do |schema_nested|
+            schema_nested.properties.each do |property|
+              if property.is_a?(Array)
+                property = property[1]
+              end
+              properties.push property
+            end
+          end
+        end
+        properties
+      end
+
+      def get_all_of_hash(schema)
+        properties = Hash.new
+        if schema["allOf"]
+          all_of = schema["allOf"]
+        end
+        if !all_of.blank?
+          all_of.each do |schema_nested|
+            schema_nested.properties.each do |key, property|
+              properties[key] = property
+            end
+          end
+        end
+        properties
+      end
+
+      def get_renderer(file)
+        template_path = File.join(File.dirname(__FILE__), 'templates/' + file)
+        template = File.open(template_path, 'r').read
+        ERB.new(template)
+      end
+
+      def get_operations(path)
+        operations = {}
+        operations['get'] = path.get if defined? path.get
+        operations['put'] = path.put if defined? path.put
+        operations['post'] = path.post if defined? path.post
+        operations['delete'] = path.delete if defined? path.delete
+        operations['patch'] = path.patch if defined? path.patch
+        operations
+      end
+
+      def get_schema_name(text)
+        unless text.is_a?(String)
+          return nil
+        end
+
+        # Schema dictates that it's always components['schemas']
+        text.gsub(/#\/components\/schemas\//, '')
+      end
+
+      def get_schema_link(schema)
+        schema_name = get_schema_name schema.node_context.source_location.to_s
+        if !schema_name.nil?
+          id = "schema-#{schema_name.parameterize}"
+          output = "<a href='\##{id}'>#{schema_name}</a>"
+          output
+        end
+      end
+    end
+  end
+end

--- a/lib/govuk_tech_docs/api_reference/templates/api_reference_full.html.erb
+++ b/lib/govuk_tech_docs/api_reference/templates/api_reference_full.html.erb
@@ -1,0 +1,20 @@
+<h1 id="<%=  info.title.parameterize %>"><%= info.title %> v<%= info.version %></h1>
+
+<%= markdown(info.description) %>
+
+<% unless servers.empty? %>
+  <h2 id="servers">Servers</h2>
+  <div id="server-list">
+    <% servers.each do |server| %>
+    <% if server.description %>
+    <p><strong><%= server.description %></strong></p>
+    <% end %>
+    <a href="<%= server.url %>"><%= server.url %></a>
+  <% end %>
+  </div>
+<% end %>
+
+<%= paths %>
+
+<h2 id="schemas">Schemas</h2>
+<%= schemas %>

--- a/lib/govuk_tech_docs/api_reference/templates/operation.html.erb
+++ b/lib/govuk_tech_docs/api_reference/templates/operation.html.erb
@@ -1,0 +1,11 @@
+<h3 id="<%= id %>"><%= key %></h3>
+<% if operation.summary %>
+  <p><em><%= operation.summary %></em></p>
+<% end %>
+<% if operation.description %>
+  <p><%= markdown(operation.description) %></p>
+<% end %>
+
+<%= parameters %>
+
+<%= responses %>

--- a/lib/govuk_tech_docs/api_reference/templates/parameters.html.erb
+++ b/lib/govuk_tech_docs/api_reference/templates/parameters.html.erb
@@ -1,0 +1,28 @@
+<% if parameters.any? %>
+<h4 id="<%= id %>">Parameters</h4>
+<table>
+<thead>
+<tr><th>Parameter</th><th>In</th><th>Type</th><th>Required</th><th>Description</th></tr>
+</thead>
+<tbody>
+<% parameters.each do |parameter| %>
+<tr>
+<td><%= parameter.name %></td>
+<td><%= parameter.in %></td>
+<td><%= parameter.schema.type %></td>
+<td><%= parameter.required? %></td>
+<td><%= markdown(parameter.description) %>
+<% if parameter.schema.enum %>
+<p>Available items:</p>
+<ul>
+<% parameter.schema.enum.each do |item| %>
+<li><%= item %></li>
+<% end %>
+</ul>
+<% end %>
+</td>
+</tr>
+<% end %>
+</tbody>
+</table>
+<% end %>

--- a/lib/govuk_tech_docs/api_reference/templates/path.html.erb
+++ b/lib/govuk_tech_docs/api_reference/templates/path.html.erb
@@ -1,0 +1,4 @@
+<% if text %>
+<h2 id="<%= id %>"><%= text %></h2>
+<% end %>
+<%= operations %>

--- a/lib/govuk_tech_docs/api_reference/templates/responses.html.erb
+++ b/lib/govuk_tech_docs/api_reference/templates/responses.html.erb
@@ -1,0 +1,33 @@
+<% if responses.any? %>
+<h4 id="<%= id %>">Responses</h4>
+<table>
+<thead>
+<tr><th>Status</th><th>Description</th><th>Schema</th></tr>
+</thead>
+<tbody>
+<% responses.each do |key,response| %>
+<tr>
+<td><%= key %></td>
+<td>
+<%= markdown(response.description) %>
+<% if response.content['application/json']
+if response.content['application/json']["example"]
+  request_body = json_prettyprint(response.content['application/json']["example"])
+else
+  request_body = json_output(response.content['application/json'].schema)
+end
+end %>
+<% if !request_body.blank? %>
+<pre><code><%= request_body %></code></pre>
+<% end %>
+</td>
+<td>
+<%= if response.content['application/json']
+  get_schema_link(response.content['application/json'].schema)
+end %>
+</td>
+</tr>
+<% end %>
+</tbody>
+</table>
+<% end %>

--- a/lib/govuk_tech_docs/api_reference/templates/schema.html.erb
+++ b/lib/govuk_tech_docs/api_reference/templates/schema.html.erb
@@ -1,0 +1,29 @@
+<h3 id="<%= id = 'schema-' + title; id.parameterize %>"><%= title %></h3>
+<%= markdown(schema.description) %>
+<% if properties.any? %>
+<table>
+<thead>
+<tr><th>Name</th><th>Type</th><th>Required</th><th>Description</th><th>Schema</th></tr>
+</thead>
+<tbody>
+<% properties.each do |property| %>
+<tr>
+<td><%= property[0] %></td>
+<td><%= property[1].type %></td>
+<td><%= property[1].required.present? %></td>
+<td><%= markdown(property[1].description) %></td>
+<td>
+  <%=
+  schema = property[1]
+  # If property is an array, check the items property for a reference.
+  if property[1].type == 'array'
+    schema = property[1]['items']
+  end
+  # Only print a link if it's a referenced object.
+  get_schema_link(schema) if schema.node_context.referenced_by.to_s.include? '#/components/schemas' and !schema.node_context.source_location.to_s.include? '/properties/' %>
+</td>
+</tr>
+<% end %>
+</tbody>
+</table>
+<% end %>

--- a/lib/govuk_tech_docs/api_reference/templates/schema.html.erb
+++ b/lib/govuk_tech_docs/api_reference/templates/schema.html.erb
@@ -1,26 +1,26 @@
 <h3 id="<%= id = 'schema-' + title; id.parameterize %>"><%= title %></h3>
 <%= markdown(schema.description) %>
 <% if properties.any? %>
-<table>
+<table class='<%= id.parameterize %>'>
 <thead>
 <tr><th>Name</th><th>Type</th><th>Required</th><th>Description</th><th>Schema</th></tr>
 </thead>
 <tbody>
-<% properties.each do |property| %>
+<% properties.each do |property_name, property_attributes| %>
 <tr>
-<td><%= property[0] %></td>
-<td><%= property[1].type %></td>
-<td><%= property[1].required.present? %></td>
-<td><%= markdown(property[1].description) %></td>
+<td><%= property_name %></td>
+<td><%= property_attributes.type %></td>
+<td><%= property_name.in?(schema.required.to_a) %></td>
+<td><%= markdown(property_attributes.description) %></td>
 <td>
   <%=
-  schema = property[1]
+  linked_schema = property_attributes
   # If property is an array, check the items property for a reference.
-  if property[1].type == 'array'
-    schema = property[1]['items']
+  if property_attributes.type == 'array'
+    linked_schema = property_attributes['items']
   end
   # Only print a link if it's a referenced object.
-  get_schema_link(schema) if schema.node_context.referenced_by.to_s.include? '#/components/schemas' and !schema.node_context.source_location.to_s.include? '/properties/' %>
+  get_schema_link(linked_schema) if linked_schema.node_context.referenced_by.to_s.include?('#/components/schemas') && !linked_schema.node_context.source_location.to_s.include?('/properties/') %>
 </td>
 </tr>
 <% end %>


### PR DESCRIPTION
### Context

There's a bug in the tech docs template that shows required attributes as optional. Is it fixed upstream, but https://github.com/alphagov/tech-docs-gem/pull/113 hasn't been merged yet. 

### Changes proposed in this pull request

We'd like to fix the bugs in the tech docs gem itself (https://github.com/alphagov/tech-docs-gem), but Pull Requests to that project take a while to get reviewed. In the meantime, we can iterate on the template inside this application by copy-pasting the templates. Once we're happy with our changes we can push the changes upstream.

### Guidance to review

See that the schemas now show the correct "required" fields.

### Release notes

- [x] [If needed](/README.md#release-notes), the [release notes](/source/release-notes.html.md) have been updated

### Link to Trello card

https://trello.com/c/mHL0Q44U/938-convert-tech-docs-to-openapi