### PR TITLE
Add other endpoints using OpenAPI

### DIFF
--- a/source/openapi-spec.yml
+++ b/source/openapi-spec.yml
@@ -117,6 +117,34 @@ paths:
                 properties:
                   data:
                     $ref: "#/components/schemas/Application"
+  "/applications/{application_id}/reject":
+    post:
+      summary: Reject an application
+      parameters:
+        - $ref: '#/components/parameters/application_id'
+      requestBody:
+        description: The reason for rejection
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                data:
+                  type: object
+                  properties:
+                    reason:
+                      type: string
+                      example: Does not meet minimum GCSE requirements
+      responses:
+        "201":
+          description: An application
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    $ref: "#/components/schemas/Application"
 components:
   responses:
     NotFound:

--- a/source/openapi-spec.yml
+++ b/source/openapi-spec.yml
@@ -87,6 +87,21 @@ paths:
                 properties:
                   data:
                     $ref: "#/components/schemas/Application"
+  "/applications/{application_id}/confirm-enrolment":
+    post:
+      summary: Confirm candidate enrolment
+      parameters:
+        - $ref: '#/components/parameters/application_id'
+      responses:
+        "204":
+          description: An application
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    $ref: "#/components/schemas/Application"
 components:
   responses:
     NotFound:

--- a/source/openapi-spec.yml
+++ b/source/openapi-spec.yml
@@ -102,6 +102,21 @@ paths:
                 properties:
                   data:
                     $ref: "#/components/schemas/Application"
+  "/applications/{application_id}/confirm-conditions-met":
+    post:
+      summary: Confirm offer conditions are met
+      parameters:
+        - $ref: '#/components/parameters/application_id'
+      responses:
+        "204":
+          description: An application
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    $ref: "#/components/schemas/Application"
 components:
   responses:
     NotFound:

--- a/source/openapi-spec.yml
+++ b/source/openapi-spec.yml
@@ -9,13 +9,7 @@ paths:
     get:
       summary: Retrieve an application
       parameters:
-        - name: application_id
-          in: path
-          required: true
-          description: The unique ID of this application
-          schema:
-            type: string
-            maxLength: 10
+        - $ref: "#/components/parameters/application_id"
       responses:
         "200":
           description: An application
@@ -26,13 +20,10 @@ paths:
                 properties:
                   data:
                     $ref: "#/components/schemas/Application"
-
-        '401':
+        "401":
           $ref: "#/components/responses/Unauthorized"
-
-        '404':
+        "404":
           $ref: "#/components/responses/NotFound"
-
   /applications:
     get:
       summary: Retrieve many applications. Applications are returned in the order they were changed or created.
@@ -65,10 +56,10 @@ paths:
                     type: array
                     items:
                       $ref: "#/components/schemas/Application"
-        '401':
+        "401":
           $ref: "#/components/responses/Unauthorized"
 
-        '404':
+        "404":
           $ref: "#/components/responses/NotFound"
 
 components:
@@ -83,7 +74,7 @@ components:
               errors:
                 type: array
                 items:
-                  $ref: '#/components/schemas/Error'
+                  $ref: "#/components/schemas/Error"
                 example:
                   error: NotFound
                   message: Unable to find Application(s)
@@ -98,7 +89,7 @@ components:
               errors:
                 type: array
                 items:
-                  $ref: '#/components/schemas/Error'
+                  $ref: "#/components/schemas/Error"
                 example:
                   error: Unauthorized
                   message: Please provide a valid authentication token
@@ -123,7 +114,6 @@ components:
           example: application
         attributes:
           $ref: "#/components/schemas/ApplicationAttributes"
-
     ApplicationAttributes:
       type: object
       additionalProperties: false
@@ -174,7 +164,6 @@ components:
           $ref: "#/components/schemas/Withdrawal"
         rejection:
           $ref: "#/components/schemas/Rejection"
-
     Candidate:
       type: object
       additionalProperties: false
@@ -415,3 +404,12 @@ components:
       required:
         - error
         - message
+  parameters:
+    application_id:
+      name: application_id
+      in: path
+      required: true
+      description: The unique ID of this application
+      schema:
+        type: string
+        maxLength: 10

--- a/source/openapi-spec.yml
+++ b/source/openapi-spec.yml
@@ -271,6 +271,9 @@ components:
             maxLength: 255
           description: The conditions of the offer
           maxItems: 20
+          example:
+            - Completion of subject knowledge enhancement
+            - Completion of professional skills test
     Qualification:
       type: object
       additionalProperties: false

--- a/source/openapi-spec.yml
+++ b/source/openapi-spec.yml
@@ -58,10 +58,35 @@ paths:
                       $ref: "#/components/schemas/Application"
         "401":
           $ref: "#/components/responses/Unauthorized"
-
         "404":
           $ref: "#/components/responses/NotFound"
+  "/applications/{application_id}/offer":
+    post:
+      summary: Make an unconditional or conditional offer
+      parameters:
+        - $ref: '#/components/parameters/application_id'
+      requestBody:
+        description: |
+          The conditions of the offer
 
+          Providing a request body with an array of conditions is equivalent to making a **conditional** offer. For an **unconditional** offer, provide an empty request body.
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                data:
+                  $ref: "#/components/schemas/Offer"
+      responses:
+        "201":
+          description: An application
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    $ref: "#/components/schemas/Application"
 components:
   responses:
     NotFound:

--- a/source/release-notes.html.md
+++ b/source/release-notes.html.md
@@ -9,12 +9,21 @@ weight: 200
 
 Changes to the data:
 
+- Change the structure an application:
+  - add `type` field
+  - add `attributes` field and move `status`, `submitted_at`, `updated_at`, `personal_statement`
+    `candidate`, `contact_details`, `course`, `qualifications`, `work_experiences`
+    `references`, `offer`, `withdrawal` and `rejection` fields into it
 - Remove date from reject endpoint
 - Rename the `org` attribute to `organisation_name` for the Work Experience resource
 - Limit candidates to only 2 nationalities
 
 Changes to functionality:
 
+- Change the successful response for all endpoints to be within a `data` object
+- Change the successful response for making an offer, confirming candidate enrolment,
+  confirming offer conditions are met and rejecting an application endpoints to be
+  the application
 - Support an `order` parameter when [retrieving many applications](/retrieve-many-applications)
 
 Additional changes:


### PR DESCRIPTION
### Context

We've decided to make a move towards OpenAPI:

- To make sure we don't make any mistakes in the API specification
- To be able to present the specification in a standard format to vendors — Ellucian explicitly requested it
- To make the docs machine-readable, to drive automated tests and act as a dummy implementation

We added in retrieve an application and many applications in #64, now we need to convert the other endpoints in our API.

### Changes proposed in this pull request

This PR adds in the following endpoints using OpenAPi:

- make an offer
- confirm candidate enrolment
- confirm conditions met
- reject an application

And makes the following changes:

- wrap request bodies in a `data` object
- return the application back for when the above endpoints and 200 response code (as I believe this is something we want to do looking at the checklist of https://trello.com/c/qPM2uTa9/957-iterate-api-calls-and-methods-to-be-more-aligned-to-standards)

### Guidance to review

Would like some feedback on:

- Whether or not the `data` object should have an `attributes` object and others like `Application`? My thought is no as it's different to an application, you can't retrieve an offer. 🤔
- Whether or not the response is what we want it to be
- Whether or not the response code is correct

### Release notes

- [ ] [If needed](/README.md#release-notes), the [release notes](/source/release-notes.html.md) have been updated

Will be updated when we're sure about the potential changes to the request and response of endpoints.

### Link to Trello card

[938 - Convert tech docs to OpenAPI](https://trello.com/c/mHL0Q44U/938-convert-tech-docs-to-openapi)