### PR TITLE
Add error responses to openapi docs

### DIFF
--- a/source/openapi-spec.yml
+++ b/source/openapi-spec.yml
@@ -357,3 +357,18 @@ components:
           type: string
           description: A brief written description of the work involved
           example: "I lead, develop and enhance the literacy teaching practice of others..."
+    Error:
+      type: object
+      additionalProperties: false
+      properties:
+        error:
+          type: string
+          description: Name of the current error
+          example: "Unauthorized"
+        message:
+          type: string
+          description: Description of the current error
+          example: Please provide a valid authentication token
+      required:
+        - error
+        - message

--- a/source/openapi-spec.yml
+++ b/source/openapi-spec.yml
@@ -26,6 +26,13 @@ paths:
                 properties:
                   data:
                     $ref: "#/components/schemas/Application"
+
+        '401':
+          $ref: "#/components/responses/Unauthorized"
+
+        '404':
+          $ref: "#/components/responses/NotFound"
+
   /applications:
     get:
       summary: Retrieve many applications. Applications are returned in the order they were changed or created.
@@ -58,7 +65,43 @@ paths:
                     type: array
                     items:
                       $ref: "#/components/schemas/Application"
+        '401':
+          $ref: "#/components/responses/Unauthorized"
+
+        '404':
+          $ref: "#/components/responses/NotFound"
+
 components:
+  responses:
+    NotFound:
+      description: Not found
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              errors:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Error'
+                example:
+                  error: NotFound
+                  message: Unable to find Application(s)
+
+    Unauthorized:
+      description: Unauthorized
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              errors:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Error'
+                example:
+                  error: Unauthorized
+                  message: Please provide a valid authentication token
   schemas:
     Application:
       type: object

--- a/source/release-notes.html.md
+++ b/source/release-notes.html.md
@@ -22,6 +22,7 @@ Additional changes:
 - Clarify the endpoint for rejecting an application in usage scenarios
 - Clarify the timestamp format for retrieving applications in usage scenarios
 - Add description of the API versioning
+- Add error responses to OpenAPI spec for application endpoints
 
 ### Release 0.3 - 16 September 2019
 


### PR DESCRIPTION
### Context

Currently the documentation does not outline the error responses from the api.
Vendors need to know what happens so they can give feedback.

### Changes proposed in this pull request

<img width="796" alt="Screenshot 2019-09-19 at 14 36 00" src="https://user-images.githubusercontent.com/47318392/65248904-de66eb00-daea-11e9-81fe-a255dc6fd96e.png">

<img width="770" alt="Screenshot 2019-09-19 at 14 35 52" src="https://user-images.githubusercontent.com/47318392/65248910-e1fa7200-daea-11e9-8472-5b3ac35b7145.png">


- Add Error schema to outline the default attributes of an error response.
- Add Error responses to the `/applications` endpoints

### Guidance to review

Check the `openapi-spec.yml` file to ensure the error schema is correct.
### Release notes

- [x] [If needed](/README.md#release-notes), the [release notes](/source/release-notes.html.md) have been updated

### Link to Trello card

[938 - Open Api tech docs](https://trello.com/c/mHL0Q44U/938-convert-tech-docs-to-openapi)
