### PR TITLE
Add instructions on how to import our OpenAPI specification in the Swagger Editor

### DIFF
--- a/source/reference.html.md
+++ b/source/reference.html.md
@@ -3,3 +3,15 @@ title: API reference
 ---
 
 api>
+
+## How to import our OpenAPI specification in the Swagger Editor
+
+As we've described our API using the <a href="https://swagger.io/docs/specification/about/" target="_blank">
+OpenAPI specification</a>, it's possible to use the <a href="https://swagger.io/tools/swagger-editor/" target="_blank">
+Swagger Editor</a> to try it out.
+
+1. Go to the <a href="https://editor.swagger.io/" target="_blank">Swagger Editor</a>
+2. Click on the **File** dropdown on the menu bar
+3. Click on **Import URL**
+4. Enter the following URL: `apply-for-postgraduate-teacher-training-tech-docs.cloudapps.digital/openapi-spec.yml`
+5. Click on **OK**

--- a/source/release-notes.html.md
+++ b/source/release-notes.html.md
@@ -23,6 +23,7 @@ Additional changes:
 - Clarify the timestamp format for retrieving applications in usage scenarios
 - Add description of the API versioning
 - Add error responses to OpenAPI spec for application endpoints
+- Add instructions for importing our OpenAPI specification in the Swagger Editor
 
 ### Release 0.3 - 16 September 2019
 


### PR DESCRIPTION
### Context

As we are using the OpenAPI specification to describe our API, this gives us and other developers access to a number of open source tools such as the [Swagger Editor](https://swagger.io/tools/swagger-editor/).

### Changes proposed in this pull request

This PR adds instructions on how to import our OpenAPI specification in the Swagger Editor.

### Guidance to review

- Does it make sense?
- Is there any more information that should be added?

### Release notes

- [x] [If needed](/README.md#release-notes), the [release notes](/source/release-notes.html.md) have been updated

### Link to Trello card

[938 - Convert tech docs to OpenAPI](https://trello.com/c/mHL0Q44U/938-convert-tech-docs-to-openapi)
