### PR TITLE
Add request body to GOV.UK Tech Docs template

### DIFF
--- a/lib/govuk_tech_docs/api_reference/api_reference_renderer.rb
+++ b/lib/govuk_tech_docs/api_reference/api_reference_renderer.rb
@@ -14,6 +14,7 @@ module GovukTechDocs
         @template_schema = get_renderer('schema.html.erb')
         @template_operation = get_renderer('operation.html.erb')
         @template_parameters = get_renderer('parameters.html.erb')
+        @template_request_body = get_renderer('request_body.html.erb')
         @template_responses = get_renderer('responses.html.erb')
       end
 
@@ -136,6 +137,7 @@ module GovukTechDocs
         operations.compact.each do |key, operation|
           id = "#{path_id}-#{key.parameterize}"
           parameters = parameters(operation, id)
+          request_body = request_body(operation, id)
           responses = responses(operation, id)
           output += @template_operation.result(binding)
         end
@@ -146,6 +148,13 @@ module GovukTechDocs
         parameters = operation.parameters
         id = "#{operation_id}-parameters"
         output = @template_parameters.result(binding)
+        output
+      end
+
+      def request_body(operation, operation_id)
+        request_body = operation.request_body
+        id = "#{operation_id}-request-body"
+        output = @template_request_body.result(binding)
         output
       end
 

--- a/lib/govuk_tech_docs/api_reference/templates/operation.html.erb
+++ b/lib/govuk_tech_docs/api_reference/templates/operation.html.erb
@@ -8,4 +8,6 @@
 
 <%= parameters %>
 
+<%= request_body %>
+
 <%= responses %>

--- a/lib/govuk_tech_docs/api_reference/templates/request_body.html.erb
+++ b/lib/govuk_tech_docs/api_reference/templates/request_body.html.erb
@@ -1,0 +1,12 @@
+<% unless request_body.nil? %>
+  <h4 id="<%= id %>">Request body</h4>
+  <%= markdown(request_body.description) %>
+  <% if request_body.content['application/json']
+    if request_body.content['application/json']["example"]
+      example = json_prettyprint(request_body.content['application/json']["example"])
+    else
+      example = json_output(request_body.content['application/json'].schema)
+    end
+  end %>
+  <pre><code><%= example %></code></pre>
+<% end %>


### PR DESCRIPTION
### Context

The GOV.UK Tech Docs template doesn't display the request body of an endpoint.

### Changes proposed in this pull request

This PR adds the functionality to display the request body of an endpoint.

![image](https://user-images.githubusercontent.com/42817036/65321505-47f30200-db9c-11e9-8c66-ecfedf1aa5fc.png)

### Guidance to review

WIP

### Release notes

- [ ] [If needed](/README.md#release-notes), the [release notes](/source/release-notes.html.md) have been updated

### Link to Trello card

[928 - Convert tech docs to OpenAPI](https://trello.com/c/mHL0Q44U/938-convert-tech-docs-to-openapi)
