### PR TITLE
Remove schema links from api responses

### DIFF
--- a/lib/govuk_tech_docs/api_reference/templates/responses.html.erb
+++ b/lib/govuk_tech_docs/api_reference/templates/responses.html.erb
@@ -2,7 +2,7 @@
 <h4 id="<%= id %>">Responses</h4>
 <table>
 <thead>
-<tr><th>Status</th><th>Description</th><th>Schema</th></tr>
+<tr><th>Status</th><th>Description</th></tr>
 </thead>
 <tbody>
 <% responses.each do |key,response| %>
@@ -20,11 +20,6 @@ end %>
 <% if !request_body.blank? %>
 <pre><code><%= request_body %></code></pre>
 <% end %>
-</td>
-<td>
-<%= if response.content['application/json']
-  get_schema_link(response.content['application/json'].schema)
-end %>
 </td>
 </tr>
 <% end %>


### PR DESCRIPTION
### Context

GovUK Tech Docs tries to display a link to the schema object of an api response. 
This is not helpful when TechDocs does not currently show OpenApi-3 response objects on the page so the link doesn't provide any use.

### Changes proposed in this pull request

Before
<img width="1568" alt="Screenshot 2019-09-23 at 09 41 04" src="https://user-images.githubusercontent.com/47318392/65412607-7add0600-dde7-11e9-908e-92db42e0e0a4.png">

After
<img width="646" alt="Screenshot 2019-09-23 at 09 40 39" src="https://user-images.githubusercontent.com/47318392/65412583-70227100-dde7-11e9-8dda-4380067a9e04.png">

To remove the Schema column from the response table in the tech docs. 

### Guidance to review

Check the OpenApi page in the tech docs to ensure that the schema link for responses is not being displayed.

### Release notes

- [x] [If needed](/README.md#release-notes), the [release notes](/source/release-notes.html.md) have been updated

### Link to Trello card

[938 - Convert tech docs to OpenApi](https://trello.com/c/mHL0Q44U/938-convert-tech-docs-to-openapi)
