### PR TITLE
Add Provider param to /applications endpoint

### DIFF
--- a/source/openapi-spec.yml
+++ b/source/openapi-spec.yml
@@ -53,6 +53,12 @@ paths:
             enum:
               - newest_first
               - oldest_first
+        - name: provider_code
+          description: UCAS Provider Code to uniquely identify a provider
+          in: query
+          required: true
+          schema:
+            type: string
       responses:
         "200":
           description: An array of applications

--- a/source/release-notes.html.md
+++ b/source/release-notes.html.md
@@ -16,6 +16,7 @@ Changes to the data:
 Changes to functionality:
 
 - Support an `order` parameter when [retrieving many applications](/retrieve-many-applications)
+- Support a `provider_code` parameter when [retrieving many applications](/retrieve-many-applications)
 
 Additional changes:
 


### PR DESCRIPTION
### Context

Users using the vendor api need to be able to specify what provider they want to retrieve applications for. 

### Changes proposed in this pull request

Before
<img width="804" alt="Screenshot 2019-09-23 at 12 19 35" src="https://user-images.githubusercontent.com/47318392/65421819-a3232f80-ddfc-11e9-9caa-1376884a2d34.png">

After
<img width="823" alt="Screenshot 2019-09-23 at 12 23 12" src="https://user-images.githubusercontent.com/47318392/65421935-f5645080-ddfc-11e9-932b-f2c7b76e90d3.png">

### Guidance to review

Check the OpenApi page to ensure the `/applications` endpoint now requires the provider query parameter. 
### Release notes

- [x] [If needed](/README.md#release-notes), the [release notes](/source/release-notes.html.md) have been updated

### Link to Trello card

[991 - Add Provider param to applications endpoint](https://trello.com/c/v9oxOLDF/991-add-provider-param-to-applications-endpoint)
