### PR TITLE
Update release notes with changed "type" keys

### DIFF
--- a/source/release-notes.html.md
+++ b/source/release-notes.html.md
@@ -12,6 +12,8 @@ Changes to the data:
 - Remove date from reject endpoint
 - Rename the `org` attribute to `organisation_name` for the Work Experience resource
 - Limit candidates to only 2 nationalities
+- Rename the `type` field on `qualification` to `qualification_type`
+- Rename the `type` field on `reference` to `reference_type`
 
 Changes to functionality:
 


### PR DESCRIPTION
### Context

These fields were renamed when we moved to OpenAPI but the changes were not documented

### Changes proposed in this pull request

Add a note to the changelog.

### Release notes

- [X] [If needed](/README.md#release-notes), the [release notes](/source/release-notes.html.md) have been updated

### Link to Trello card

https://trello.com/c/mHL0Q44U/938-convert-tech-docs-to-openapi
