### PR TITLE
Update authentication docs to cover API Key workflow

### DIFF
--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -7,7 +7,9 @@ weight: 0
 
 This is REST API documentation for the Department for Education’s new "Apply for postgraduate teacher training" service.
 
-Apply will replace the online UCAS application form for postgraduate teacher training. All vendors of student record systems and some training providers will need to make changes to integrate with Apply.
+Apply will replace the online UCAS application form for postgraduate
+teacher training. All vendors of student record systems (SRS) and some
+training providers will need to make changes to integrate with Apply.
 
 The API is a work in progress. We are publishing draft documentation so that:
 
@@ -44,42 +46,28 @@ Codes appear in three contexts:
 
 ### Authentication and authorisation
 
-The data held by the Apply service is confidential, only available
+The data held by the Apply service is confidential and only available
 to candidates themselves and staff from the training provider to
 which applications are made. Therefore authentication will be required
 for all API interactions.
 
-Training Provider Staff identify themselves to Apply using DfE
-Sign-in, the Single Sign-on service used on the existing _Publish
-teacher training courses_ service. This means that the rules
-around who is able to see and do what all live inside the Apply
-service and student record systems (SRS) will not need to deal with
-authorization.
+To set up an authenticated connection between the student record
+system and DfE Apply, users will need to provide an API key to
+the SRS. To get an API key, the user will need to sign in to the DfE
+Apply web interface using DfE Sign-in, the Single Sign-on provider
+used on the existing _Publish teacher training courses_ service, part
+of <a
+href="https://find-postgraduate-teacher-training.education.gov.uk"
+target="_blank">Find postgraduate teacher training</a>. For each
+provider supported by your SRS, one user needs to generate this
+key. It is up to SRS vendors to provide a way for users to add the API
+key their SRS system.
 
-Your existing users will be grant your SRS access to the Apply API on
-their behalf via DfE Sign-in, which uses an [OpenID
-Connect](https://openid.net/connect/faq/) flow. This works in the
-following way:
-
-1. A user is logged into the SRS and tries to perform some action
-   involving an API call, such as downloading applications or issuing
-   an offer, triggering a request to the API
-1. The API returns a 401 Unauthorized response
-1. The SRS opens a popup web browser window containing a DfE Sign-in
-   login screen
-1. The user signs in to DfE Sign-in and confirms that the SRS may
-   access their data on Apply
-1. The user is redirected back to the SRS with an authorization code,
-   which the SRS exchanges with DfE Sign-in for an access token and
-   refresh token
-1. The SRS stores the access token, which is associated with the user,
-   and includes it on subsequent requests to the API
-
-The access token will eventually expire, at which point the SRS will
-once again receive a 401 Unauthorized response from Apply. When this
-happens the refresh token may be exchanged for a fresh access token
-and, assuming the user is still authorized to access the resources in
-question.
+The API key will expire after 6 months. One month in advance of
+expiry, DfE Apply will email the user who generated the key so that
+they know to come back and generate a new one. To prevent a hard
+cut-over between keys, once a new key is created the old key will
+continue to work until it expires.
 
 _Last updated: <%= Date.today.strftime("%-d %B %Y") %>_
 

--- a/source/openapi-spec.yml
+++ b/source/openapi-spec.yml
@@ -637,3 +637,9 @@ components:
       schema:
         type: string
         maxLength: 10
+  securitySchemes:
+    tokenAuth:
+      type: http
+      scheme: bearer
+security:
+  - tokenAuth: []

--- a/source/release-notes.html.md
+++ b/source/release-notes.html.md
@@ -43,6 +43,8 @@ Additional changes:
 - Update responses for making an offer, confirming candidate enrolment,
   confirming offer conditions are met and rejecting an application endpoints in usage scenarios
 - Clarify Max length of strings in Schemas
+- Document the workflow for authenticating with an API key
+- Remove documentation for OpenID Connect, which will not be supported
 
 ### Release 0.3 - 16 September 2019
 


### PR DESCRIPTION
Remove the OpenID documentation, as the largest vendor cannot support
it. Replace with a simpler flow where users provide API keys via their SRS.

### Context

The biggest vendor, Tribal, cannot support the OpenID flow, so we need another one. This is our best effort.

### Changes proposed in this pull request

Remove the old OpenID flow because we don't want to support two flows. Add the new flow.

### Guidance to review

Check the prose. Does the flow make sense?

### Release notes

- [X] [If needed](/README.md#release-notes), the [release notes](/source/release-notes.html.md) have been updated

https://trello.com/c/zTxAAPuf/962-continue-the-authentication-story-without-openid-direct-connect