### PR TITLE
Update usage scenarios to replace JSON methods

### DIFF
--- a/source/release-notes.html.md
+++ b/source/release-notes.html.md
@@ -36,6 +36,9 @@ Additional changes:
 - Add description of the API versioning
 - Add error responses to OpenAPI spec for application endpoints
 - Add instructions for importing our OpenAPI specification in the Swagger Editor
+- Add `provider_code` param to retrieving many applications in usage scenarios
+- Update responses for making an offer, confirming candidate enrolment,
+  confirming offer conditions are met and rejecting an application endpoints in usage scenarios
 
 ### Release 0.3 - 16 September 2019
 

--- a/source/usage-scenarios.html.md.erb
+++ b/source/usage-scenarios.html.md.erb
@@ -15,14 +15,10 @@ At the beginning of each scenario, a candidate has completed an application for 
 The provider has authenticated to your system and begins their work by retrieving all the applications since a given date. Your system issues the following request on their behalf:
 
 ```
-GET /applications?since=2018-10-01T10:00:00Z
+GET /applications?since=2018-10-01T10:00:00Z&provider_code=2FR
 ```
 
-This returns a list of <%= link_to_resource_definition('Application') %>s:
-
-```json
-<%= applications_json %>
-```
+This returns a list of [Application](/reference/#application)s.
 
 The following examples all refer to a single application id, `11fc0d3b2f`, which
 we assume belongs to one of the applications in that list.
@@ -37,9 +33,9 @@ Get the application data.
 GET /applications/11fc0d3b2f
 ```
 
-```json
-<%= single_application_json %>
-```
+This returns an [application](/reference/#application).
+
+_See [retrieve an application](/reference/#get-applications-application-id) endpoint._
 
 ### 2. The provider makes an offer
 
@@ -49,11 +45,11 @@ The provider would like to offer the candidate a conditional place.
 POST /applications/11fc0d3b2f/offer
 ```
 
-```json
-<%= offer_json %>
-```
+With a [request body containing conditions](/reference/#request-body).
 
-Make this request again if you want to amend the offer.
+This returns an [application](/reference/#application) with an updated `status`.
+
+_See [make an offer](/reference/#post-applications-application-id-offer) endpoint._
 
 ### 3. Confirm that the conditions are met
 
@@ -63,6 +59,10 @@ Once you know the conditions are met, make the following request.
 POST /applications/11fc0d3b2f/confirm-conditions-met
 ```
 
+This returns an [application](/reference/#application) with an updated `status`.
+
+_See [confirm offer conditions are met](/reference/#post-applications-application-id-confirm-conditions-met) endpoint._
+
 ### 4. Confirm candidate enrolment
 
 Once the candidate has onboarded, make the following request.
@@ -70,6 +70,10 @@ Once the candidate has onboarded, make the following request.
 ```
 POST /applications/11fc0d3b2f/confirm-enrolment
 ```
+
+This returns an [application](/reference/#application) with an updated `status`.
+
+_See [confirm candidate enrolment](/reference/#post-applications-application-id-confirm-enrolment) endpoint._
 
 ## Rejecting an application
 
@@ -79,6 +83,8 @@ POST /applications/11fc0d3b2f/confirm-enrolment
 POST /applications/11fc0d3b2f/reject
 ```
 
-```json
-<%= rejection_json %>
-```
+With a [request body containing a reason](/reference/#post-applications-application-id-reject-request-body).
+
+This returns an [application](/reference/#application) with an updated `status`.
+
+_See [reject an application](/reference/#post-applications-application-id-reject) endpoint._


### PR DESCRIPTION
### Context

We've moved towards using OpenAPI to describe our API and in the `Usage scenarios` section we are using our old way of documenting it which will soon cease to exist.

### Changes proposed in this pull request

This PR replaces usage of `single_application_json`, `applications_json`, `offer_json` and `rejection_json` with appropriate links out to the `API reference` section.

It also adds a link to the endpoint for each step.

### Guidance to review

I would like feedback on the tradeoff we're making here and if we're okay making it. By linking out to say the request body of an endpoint, we don't have to update it here if the request body changes. However, it can be argued it's nicer to have the request body visible on the current page but this would require additional implementation to get it from OpenAPI spec.

### Release notes

- [x] [If needed](/README.md#release-notes), the [release notes](/source/release-notes.html.md) have been updated

### Link to Trello card

[1000 - Update `Usage scenarios` section](https://trello.com/c/kUjbJ1cH/1000-update-usage-scenarios-section)
