### PR TITLE
Require attribution and dating meta on update requests

### DIFF
--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -69,8 +69,6 @@ they know to come back and generate a new one. To prevent a hard
 cut-over between keys, once a new key is created the old key will
 continue to work until it expires.
 
-_Last updated: <%= Date.today.strftime("%-d %B %Y") %>_
-
 ### Versioning
 
 The version of the API is specified in the URL `/api/v{n}/`. For example: `/api/v1/`, `/api/v2/`, `/api/v3/`, ...
@@ -86,4 +84,6 @@ When non-breaking changes are made to the API, this will not result in a version
 Information about deprecations (for instance attributes/endpoints that will be modified/removed) will be included in the API
 response through a "Warning" header.
 
-We will update our [release notes](/release-notes) containing all breaking and non-breaking changes.
+We will update our [release notes](/release-notes) with all breaking and non-breaking changes.
+
+_Last updated: <%= Date.today.strftime("%-d %B %Y") %>_

--- a/source/openapi-spec.yml
+++ b/source/openapi-spec.yml
@@ -88,6 +88,8 @@ paths:
               properties:
                 data:
                   $ref: "#/components/schemas/Offer"
+                meta:
+                  $ref: '#/components/schemas/TimestampAndAttribution'
       responses:
         "200":
           description: An application
@@ -108,6 +110,14 @@ paths:
       description: Confirm that the candidate has enroled
       parameters:
         - $ref: '#/components/parameters/application_id'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                meta:
+                  $ref: '#/components/schemas/TimestampAndAttribution'
       responses:
         "200":
           description: An application
@@ -128,6 +138,14 @@ paths:
       description: Confirm that the candidate has met all the conditions set out in the offer
       parameters:
         - $ref: '#/components/parameters/application_id'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                meta:
+                  $ref: '#/components/schemas/TimestampAndAttribution'
       responses:
         "200":
           description: An application
@@ -161,6 +179,8 @@ paths:
                     reason:
                       type: string
                       example: Does not meet minimum GCSE requirements
+                meta:
+                  $ref: '#/components/schemas/TimestampAndAttribution'
       responses:
         "200":
           description: An application
@@ -617,6 +637,40 @@ components:
           type: string
           description: The candidate’s ethnicity as a two-digit HESA code (https://www.hesa.ac.uk/collection/c19053/e/ethnic)
           example: "10"
+    Attribution:
+      type: object
+      additionalProperties: false
+      required:
+        - full_name
+        - email
+        - user_id
+      properties:
+        full_name:
+          type: string
+          description: The full name of the user who made this update
+          example: "Jane Smith"
+        email:
+          type: string
+          description: The email address of the user who made this update
+          example: "jane.smith@example.com"
+        user_id:
+          type: string
+          description: The ID of the user in the Student Record System, used for disambiguation
+          example: "12345"
+    TimestampAndAttribution:
+      type: object
+      description: Required under a "meta" key in the body of every POST or PUT request
+      additionalProperties: false
+      required:
+        - attribution
+        - timestamp
+      properties:
+        attribution:
+          $ref: '#/components/schemas/Attribution'
+        timestamp:
+          type: string
+          description: The time this update was made, formatted as an ISO 8601 timestamp with time zone
+          format: date-time
     Error:
       type: object
       additionalProperties: false

--- a/source/release-notes.html.md
+++ b/source/release-notes.html.md
@@ -24,13 +24,14 @@ Changes to the data:
 Changes to functionality:
 
 - Change the successful response for all endpoints to be within a `data` object
-- Change the successful response for [making an offer](/reference/#post-applications-application-id-offer),
-  [confirming candidate enrolment](/reference/#post-applications-application-id-confirm-enrolment),
-  [confirming offer conditions are met](/reference/#post-applications-application-id-confirm-conditions-met)
-  and [rejecting an application](/reference/#post-applications-application-id-reject) endpoints to:
-  - return the application
-  - return a HTTP `200` response code
-- Support an `order` and a `provider_code` parameter when [retrieving many applications](/reference#get-applications)
+- Change the successful response for making an offer, confirming candidate
+  enrolment, confirming offer conditions are met and rejecting an application
+  endpoints to be the application
+- Change the HTTP response code for making an offer, confirming candidate enrolment,
+  confirming offer conditions are met and rejecting an application endpoints to `200`
+- Support an `order` parameter when [retrieving many applications](/retrieve-many-applications)
+- Support a `provider_code` parameter when [retrieving many applications](/retrieve-many-applications)
+- Require a `meta` key in POST request bodies, holding `attribution` and `timestamp` metadata
 
 Additional changes:
 


### PR DESCRIPTION
Insist that clients provide a `meta` key with attribution and timestamp on each update.

### Context

We need this information for auditing (attribution) and consistency (timestamp).

### Guidance to review

Are the schemas correctly set up? Are they present on all the right endpoints?

### Release notes

- [X] [If needed](/README.md#release-notes), the [release notes](/source/release-notes.html.md) have been updated

### Link to Trello card

https://trello.com/c/HNAo4nyN/1002-document-api-metadata-about-time-and-attribution-who-did-what-when
