### PR TITLE
Update HTTP response codes on some endpoints

### DIFF
--- a/source/openapi-spec.yml
+++ b/source/openapi-spec.yml
@@ -100,7 +100,7 @@ paths:
       parameters:
         - $ref: '#/components/parameters/application_id'
       responses:
-        "204":
+        "200":
           description: An application
           content:
             application/json:

--- a/source/openapi-spec.yml
+++ b/source/openapi-spec.yml
@@ -143,7 +143,7 @@ paths:
                       type: string
                       example: Does not meet minimum GCSE requirements
       responses:
-        "201":
+        "200":
           description: An application
           content:
             application/json:

--- a/source/openapi-spec.yml
+++ b/source/openapi-spec.yml
@@ -115,7 +115,7 @@ paths:
       parameters:
         - $ref: '#/components/parameters/application_id'
       responses:
-        "204":
+        "200":
           description: An application
           content:
             application/json:

--- a/source/openapi-spec.yml
+++ b/source/openapi-spec.yml
@@ -85,7 +85,7 @@ paths:
                 data:
                   $ref: "#/components/schemas/Offer"
       responses:
-        "201":
+        "200":
           description: An application
           content:
             application/json:

--- a/source/release-notes.html.md
+++ b/source/release-notes.html.md
@@ -27,6 +27,8 @@ Changes to functionality:
 - Change the successful response for making an offer, confirming candidate enrolment,
   confirming offer conditions are met and rejecting an application endpoints to be
   the application
+- Change the HTTP response code for making an offer, confirming candidate enrolment,
+  confirming offer conditions are met and rejecting an application endpoints to `200`
 - Support an `order` parameter when [retrieving many applications](/retrieve-many-applications)
 - Support a `provider_code` parameter when [retrieving many applications](/retrieve-many-applications)
 


### PR DESCRIPTION
### Context

We have some incorrect HTTP status codes returned for some endpoints e.g. 

- `POST /applications/{application_id}/confirm-enrolment`
- `POST /applications/{application_id}/confirm-conditions-met`

return a `204` which means `No Content` but we provide back the application.

### Changes proposed in this pull request

This PR changes the response code to `200` for the following endpoints:

- make an offer
- confirm candidate enrolment
- confirm offer conditions met
- reject application

After looking at some resources (https://httpstatusdogs.com/200-ok, https://developer.mozilla.org/en-US/docs/Web/HTTP/Status, https://www.restapitutorial.com/httpstatuscodes.html), a `200` response code seems most relevant to me for POST requests that return the updated resource (i.e. application). I considered  using `201` but it doesn't result in a new resource which I understand `Application` to be our only one. 🤔 

### Guidance to review

Whaddya think? 💭 

### Release notes

- [x] [If needed](/README.md#release-notes), the [release notes](/source/release-notes.html.md) have been updated

### Link to Trello card

[1003 - Update HTTP response codes on endpoints](https://trello.com/c/3qjlPaC8/1003-update-http-response-codes-on-endpoints)
