### PR TITLE
Update HESA ITT codes link and make external links open in a new tab

### DIFF
--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -36,8 +36,8 @@ DfE Apply will avoid prioprietary codes wherever possible, preferring existing d
 
 Codes appear in three contexts:
 
-- All dates in the API specification are intended to be [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) compliant
-- Nationality is expressed as an [ISO 3166](https://www.iso.org/iso-3166-country-codes.html) country code
+- All dates in the API specification are intended to be <a href="https://www.iso.org/iso-8601-date-and-time-format.html" target="_blank">ISO 8601</a> compliant
+- Nationality is expressed as an <a href="https://www.iso.org/iso-3166-country-codes.html" target="_blank">ISO 3166</a> country code
 - Demographic data required for HESA reporting uses <a href="https://www.hesa.ac.uk/collection/c19053/e/ittschms" target="_blank">HESA codes for the 2019/20 Initial Teacher Training return</a>. When the HESA codes for the next cycle are released, we will update the documentation to reflect these.
 
 ## How do I connect to this API?

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -38,7 +38,7 @@ Codes appear in three contexts:
 
 - All dates in the API specification are intended to be [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) compliant
 - Nationality is expressed as an [ISO 3166](https://www.iso.org/iso-3166-country-codes.html) country code
-- Demographic data required for HESA reporting uses [HESA codes for the 2019/20 Initial Teacher Training return](https://www.hesa.ac.uk/collection/c18053/e/student). When the HESA codes for the next cycle are released, we will update the documentation to reflect these.
+- Demographic data required for HESA reporting uses <a href="https://www.hesa.ac.uk/collection/c19053/e/ittschms" target="_blank">HESA codes for the 2019/20 Initial Teacher Training return</a>. When the HESA codes for the next cycle are released, we will update the documentation to reflect these.
 
 ## How do I connect to this API?
 


### PR DESCRIPTION
### Context

For linking to HESA codes for the 2019/20 Initial Teacher Training return, we link to the 2018/19 instead.

We also have links to external resources which open up in the current tab, convention is to open it up in a new tab.

### Changes proposed in this pull request

This PR fixes the incorrect link to HESA codes for 2019/20 and change external links to open in a new tab.

### Guidance to review

Just double check it's the correct HESA link.

### Release notes

- [ ] [If needed](/README.md#release-notes), the [release notes](/source/release-notes.html.md) have been updated

I don't believe we need an update to the release notes as this is something we've added in this release.

### Link to Trello card

[1006 - Make smol changes to API docs](https://trello.com/c/IgzRgSo5/1006-make-smol-changes-to-api-docs)
