### PR TITLE
Clean up links in release notes

### DIFF
--- a/source/release-notes.html.md
+++ b/source/release-notes.html.md
@@ -9,42 +9,42 @@ weight: 200
 
 Changes to the data:
 
-- Change the structure of an application:
+- Change the structure of an [application](/reference#get-applications):
   - add `type` field
   - add `attributes` field and move `status`, `submitted_at`, `updated_at`, `personal_statement`
     `candidate`, `contact_details`, `course`, `qualifications`, `work_experiences`
     `references`, `offer`, `withdrawal` and `rejection` fields into it
-- Remove date from reject endpoint
-- Rename the `org` attribute to `organisation_name` for the Work Experience resource
-- Limit candidates to only 2 nationalities
-- Rename the `type` field on `qualification` to `qualification_type`
-- Rename the `type` field on `reference` to `reference_type`
-- Add HESA ITT data to the application. Available only once a student is enrolled
+- Remove date from [reject](/reference/#post-applications-application-id-reject) endpoint
+- Limit [candidates](/reference/#candidate) to only 2 nationalities
+- Rename the `org` field on [work experience](/reference/#workexperience) to `organisation_name`
+- Rename the `type` field on [qualification](/reference/#qualification) to `qualification_type`
+- Rename the `type` field on [reference](/reference/#reference) to `reference_type`
+- Add HESA ITT data to the [application](/reference#get-applications). Available only once a student is enrolled
 
 Changes to functionality:
 
 - Change the successful response for all endpoints to be within a `data` object
-- Change the successful response for making an offer, confirming candidate enrolment,
-  confirming offer conditions are met and rejecting an application endpoints to be
-  the application
-- Change the HTTP response code for making an offer, confirming candidate enrolment,
-  confirming offer conditions are met and rejecting an application endpoints to `200`
-- Support an `order` parameter when [retrieving many applications](/retrieve-many-applications)
-- Support a `provider_code` parameter when [retrieving many applications](/retrieve-many-applications)
+- Change the successful response for [making an offer](/reference/#post-applications-application-id-offer),
+  [confirming candidate enrolment](/reference/#post-applications-application-id-confirm-enrolment),
+  [confirming offer conditions are met](/reference/#post-applications-application-id-confirm-conditions-met)
+  and [rejecting an application](/reference/#post-applications-application-id-reject) endpoints to:
+  - return the application
+  - return a HTTP `200` response code
+- Support an `order` and a `provider_code` parameter when [retrieving many applications](/reference#get-applications)
 
 Additional changes:
 
-- Clarify the endpoint for rejecting an application in usage scenarios
-- Clarify the timestamp format for retrieving applications in usage scenarios
-- Add description of the API versioning
-- Add error responses to OpenAPI spec for application endpoints
-- Add instructions for importing our OpenAPI specification in the Swagger Editor
-- Add `provider_code` param to retrieving many applications in usage scenarios
-- Update responses for making an offer, confirming candidate enrolment,
-  confirming offer conditions are met and rejecting an application endpoints in usage scenarios
-- Clarify Max length of strings in Schemas
-- Document the workflow for authenticating with an API key
-- Remove documentation for OpenID Connect, which will not be supported
+- Clarify the endpoint for rejecting an application in [usage scenarios](/usage-scenarios)
+- Clarify the timestamp format for retrieving applications in [usage scenarios](/usage-scenarios)
+- Clarify maximum length of strings in Schemas
+- Add description of the [API versioning](/#versioning)
+- Add error responses to OpenAPI spec for all endpoints
+- Add [instructions](/reference/#use-the-swagger-editor) for importing our OpenAPI specification in the Swagger Editor
+- Add `provider_code` param to retrieving many applications in [usage scenarios](/usage-scenarios)
+- Update responses for [making an offer](/reference/#post-applications-application-id-offer),
+  [confirming candidate enrolment](/reference/#post-applications-application-id-confirm-enrolment),
+  [confirming offer conditions are met](/reference/#post-applications-application-id-confirm-conditions-met)
+  and [rejecting an application](/reference/#post-applications-application-id-reject) endpoints in [usage scenarios](/usage-scenarios)
 
 ### Release 0.3 - 16 September 2019
 

--- a/source/release-notes.html.md
+++ b/source/release-notes.html.md
@@ -54,7 +54,7 @@ Changes to the data:
 - Remove id from Candidate
 - Remove disability information from Candidate, as this is not collected via the application form
 - Remove functionality to amend an offer
-- Rename the [rejection endpoint](/reject-an-application)
+- Rename the rejection endpoint
 - Update Contact Details resource to split address into separate fields
 - Remove description from course resource
 - Add first name, last name and date of birth for Candidate
@@ -64,8 +64,8 @@ Changes to the data:
 Changes to functionality:
 
 - Add documentation on the proposed way of authenticating users
-- Limit the number of [offer conditions](/make-an-offer/#attributes) to 20
-- Remove functionality to amend an offer (you can reuse the [make an offer](/make-an-offer/) endpoint)
+- Limit the number of offer conditions to 20
+- Remove functionality to amend an offer (you can reuse the make an offer endpoint)
 - Remove functionality to confirm a placement for a candidate
 - Remove functionality to schedule interviews for a candidate
 
@@ -73,11 +73,11 @@ Changes to the data:
 
 - Remove first and last name from Candidate in favour of full name
 - Remove id from Candidate
-- Remove disability information from [Candidate](/resources-and-their-attributes/#candidate), as this is not collected via the application form
-- Rename the [rejection endpoint](/reject-an-application)
+- Remove disability information from Candidate, as this is not collected via the application form
+- Rename the rejection endpoint
 - Update Contact Details resource to split address into separate fields
-- Applications now have a [10 character identifier](/resources-and-their-attributes/#application)
-- The [`course` attribute](/retrieve-a-single-application) of an application now refers to a single course instead of multiple
+- Applications now have a 10 character identifier
+- The `course` attribute of an application now refers to a single course instead of multiple
 - References have a "content" attribute containing the referee's contribution
 - Qualifications have an "equivalency_details" attribute for overseas awards
 - Withdrawals and Rejections now have timestamps instead of dates
@@ -85,11 +85,11 @@ Changes to the data:
 
 Additional changes:
 
-- Clarify that strings have a [255 character limit](/resources-and-their-attributes/#strings), unless otherwise specified
-- Clarify that only candidates can [withdraw an application](/resources-and-their-attributes/#withdrawal)
+- Clarify that strings have a 255 character limit, unless otherwise specified
+- Clarify that only candidates can withdraw an application
 - Clarify that we're using [ISO 3166 for country codes](/#codes-and-reference-data), not ISO 3611
-- Clarify how to [make an unconditional and conditional offer](/make-an-offer)
-- Clarify that [offer conditions](/make-an-offer/#attributes) are optional
+- Clarify how to make an unconditional and conditional offer
+- Clarify that offer conditions are optional
 
 ### Release 0.1 - 4 July 2019
 


### PR DESCRIPTION
### Context

We have some old links in our release notes and some places we have links and others we don't.

### Changes proposed in this pull request

This PR removes links pre-v0.3 and add links where appropriate in our current `Unreleased` section. It also merges some sentences where it seemed appropriate e.g.

```mkd
- Support an `order` parameter when [retrieving many applications](/retrieve-many-applications)	  
- Support a `provider_code` parameter when [retrieving many applications](/retrieve-many-applications)
```

has been made into a single sentence.

```mkd
- Support an `order` and a `provider_code` parameter when [retrieving many applications](/reference#get-applications)
```

### Guidance to review

Found it difficult to see changes using Git Diff so would recommend running locally and reading through to make sure it still makes sense and links are correct.

### Release notes

- [ ] [If needed](/README.md#release-notes), the [release notes](/source/release-notes.html.md) have been updated

### Link to Trello card

[1003 - Make smol changes to API docs](https://trello.com/c/IgzRgSo5/1006-make-smol-changes-to-api-docs)
