### PR TITLE
Add limit for array size to description

### DIFF
--- a/lib/govuk_tech_docs/api_reference/templates/schema.html.erb
+++ b/lib/govuk_tech_docs/api_reference/templates/schema.html.erb
@@ -17,7 +17,14 @@
   <td><%= property_name %><%= property_name.in?(schema.required.to_a) ? "<abbr title='This field will always be present in the response'>*</abbr>" : "" %></td>
   <td><%= property_attributes.type %></td>
   <td><%= property_attributes.example %></td>
-  <td><%= property_attributes.description %><%= property_attributes.type == 'string' && property_attributes.max_length.present? ? "<p>(limited to #{property_attributes.max_length} characters)</p>": "" %></td>
+  <td>
+    <%= property_attributes.description %>
+    <% if property_attributes.type == 'string' && property_attributes.max_length.present? %>
+      <p>(limited to <%= property_attributes.max_length %> characters)</p>
+    <% elsif property_attributes.type == 'array' && property_attributes.max_items.present? %>
+      <p>(limited to <%= property_attributes.max_items %> elements)</p>
+    <% end %>
+  </td>
   <td>
     <%=
     linked_schema = property_attributes

--- a/spec/lib/govuk_tech_docs/api_reference/test_docs/pets-output.html
+++ b/spec/lib/govuk_tech_docs/api_reference/test_docs/pets-output.html
@@ -197,7 +197,10 @@ Info for a specific pet
   <td>id<abbr title='This field will always be present in the response'>*</abbr></td>
   <td>integer</td>
   <td></td>
-  <td></td>
+  <td>
+    
+    
+  </td>
   <td>
     
   </td>
@@ -207,7 +210,12 @@ Info for a specific pet
   <td>name<abbr title='This field will always be present in the response'>*</abbr></td>
   <td>string</td>
   <td></td>
-  <td><p>(limited to 50 characters)</p></td>
+  <td>
+    
+    
+      <p>(limited to 50 characters)</p>
+    
+  </td>
   <td>
     
   </td>
@@ -217,7 +225,10 @@ Info for a specific pet
   <td>tag</td>
   <td>string</td>
   <td></td>
-  <td></td>
+  <td>
+    
+    
+  </td>
   <td>
     
   </td>
@@ -252,7 +263,10 @@ Info for a specific pet
   <td>code<abbr title='This field will always be present in the response'>*</abbr></td>
   <td>integer</td>
   <td></td>
-  <td></td>
+  <td>
+    
+    
+  </td>
   <td>
     
   </td>
@@ -262,7 +276,10 @@ Info for a specific pet
   <td>message<abbr title='This field will always be present in the response'>*</abbr></td>
   <td>string</td>
   <td></td>
-  <td></td>
+  <td>
+    
+    
+  </td>
   <td>
     
   </td>


### PR DESCRIPTION
### Context

We have specified `maxItems` in our OpenAPI spec but don't display it in the tech docs, e.g. nationalities can be max 2 but not visible.

### Changes proposed in this pull request

This PR adds the ability to display the max size of an array if specified.

#### Before

![image](https://user-images.githubusercontent.com/42817036/65518012-8e699900-dedb-11e9-9977-e11cff548401.png)

#### After

![image](https://user-images.githubusercontent.com/42817036/65517912-5a8e7380-dedb-11e9-8bdf-e8499e2feaa4.png)

### Release notes

- [ ] [If needed](/README.md#release-notes), the [release notes](/source/release-notes.html.md) have been updated

Don't believe it's needed as we specified size limits before converting to OpenAPI.

### Link to Trello card

[1006 - Make smol changes to API docs](https://trello.com/c/IgzRgSo5/1006-make-smol-changes-to-api-docs)
