### PR TITLE
Update application status enum

### DIFF
--- a/source/openapi-spec.yml
+++ b/source/openapi-spec.yml
@@ -250,9 +250,15 @@ components:
           type: string
           description: The status of this application
           enum:
-            - accepted
+            - application_complete
+            - conditional_offer
+            - unconditional_offer
+            - meeting_conditions
+            - recruited
+            - enrolled
             - rejected
-          example: accepted
+            - declined
+          example: conditional_offer
         submitted_at:
           type: string
           format: date-time


### PR DESCRIPTION
### Context

Currently the application status in `openapi-spec.yml` only contains `accepted` and `rejected`, which are incomplete or incorrect.
This PR aims to fix this.

### Changes proposed in this pull request
- Remove `accepted` from application status enum
- Add application states to application enum

### Guidance to review

- Check that the status that have been added look correct.

### Release notes

- [ ] [If needed](/README.md#release-notes), the [release notes](/source/release-notes.html.md) have been updated

### Link to Trello card

[1006 - Small changes to api docs](https://trello.com/c/IgzRgSo5/1006-make-small-changes-to-api-docs)
