### PR TITLE
Update usage scenario for meeting conditions

### DIFF
--- a/source/release-notes.html.md
+++ b/source/release-notes.html.md
@@ -46,6 +46,7 @@ Additional changes:
   [confirming candidate enrolment](/reference/#post-applications-application-id-confirm-enrolment),
   [confirming offer conditions are met](/reference/#post-applications-application-id-confirm-conditions-met)
   and [rejecting an application](/reference/#post-applications-application-id-reject) endpoints in [usage scenarios](/usage-scenarios)
+- Clarify the steps between making an offer and confirming that offer conditions are met in [usage scenarios](/usage-scenarios)
 
 ### Release 0.3 - 16 September 2019
 

--- a/source/usage-scenarios.html.md.erb
+++ b/source/usage-scenarios.html.md.erb
@@ -52,6 +52,7 @@ This returns an [application](/reference/#application) with an updated `status`.
 _See [make an offer](/reference/#post-applications-application-id-offer) endpoint._
 
 ### 3. Confirm that the conditions are met
+> If the candidate has accepted this offer and has worked towards meeting the offer conditions.
 
 Once you know the conditions are met, make the following request.
 


### PR DESCRIPTION
### Context
The usage scenarios don't give any clarity on the steps between the provider making an offer via the api and when to confirm when conditions are met.

### Changes proposed in this pull request

Before
<img width="812" alt="Screenshot 2019-09-25 at 11 03 36" src="https://user-images.githubusercontent.com/47318392/65591316-2cb13980-df84-11e9-8999-05514459c818.png">

After
<img width="783" alt="Screenshot 2019-09-25 at 10 51 14" src="https://user-images.githubusercontent.com/47318392/65591324-333fb100-df84-11e9-82e4-a91bb9a73011.png">

Add a note clarifying that the candidate needs to accept the offer and work toward meeting the offer conditions before a vendor and confirm that the conditions have been met.

### Guidance to review
Check the `usage scenarios` page and ensure the note at the top of step 3 makes sense.
### Release notes

- [x] [If needed](/README.md#release-notes), the [release notes](/source/release-notes.html.md) have been updated

### Link to Trello card

[1017 - Clarify meeting conditions steps](https://trello.com/c/zSf3czvJ/1017-edit-usage-scenarios-to-clarify-offer-to-meeting-conditions-steps)
