### PR TITLE
Fix bug in docs to outline how unconditional offers are requested

### DIFF
--- a/source/openapi-spec.yml
+++ b/source/openapi-spec.yml
@@ -77,7 +77,7 @@ paths:
         description: |
           The conditions of the offer
 
-          Providing a request body with an array of conditions is equivalent to making a **conditional** offer. For an **unconditional** offer, provide an empty request body.
+          Providing a request body with an array of conditions is equivalent to making a **conditional** offer. For an **unconditional** offer, provide an empty array.
         content:
           application/json:
             schema:


### PR DESCRIPTION
Edit openapi-spec to inform vendors that an unconditional offer
is requested with an empty array rather than an empty request.

### Context

Fix bug in docs. 
For unconditional offers we invite an empty post request. Which is incorrect.

### Changes proposed in this pull request

- Edit openapi-spec to change `make an offer` summary to outline that unconditional offers are requested with an empty conditions array. 

### Release notes

- [ ] [If needed](/README.md#release-notes), the [release notes](/source/release-notes.html.md) have been updated

### Link to Trello card

[1044 - Tech docs bug we invite empty request body when creating unconditional offer](https://trello.com/c/feyFGMsZ/1044-tech-docs-bug-we-invite-empty-request-body-when-creating-unconditional-offer-but-the-meta-key-is-still-required)
