### PR TITLE
Add guidance on rate limiting to the tech docs

### DIFF
--- a/source/reference.html.md.erb
+++ b/source/reference.html.md.erb
@@ -17,4 +17,13 @@ Swagger Editor</a> to try it out.
 4. Enter the following URL: `apply-for-postgraduate-teacher-training-tech-docs.cloudapps.digital/openapi-spec.yml`
 5. Click on **OK**
 
+
+## Rate limits
+
+You are limited to 120 requests per minute. 
+
+This limit is calculated on a rolling basis, per API key. 
+If you exceed the limit, you will get a `429` error `RateLimitError`.
+
+
 <%= GovukTechDocs::ApiReference::Display.new('source/openapi-spec.yml').render %>

--- a/source/release-notes.html.md
+++ b/source/release-notes.html.md
@@ -6,6 +6,7 @@ weight: 200
 # Release notes
 
 ### Unreleased Changes
+- Add [limits](/reference/#rate-limits) section to give details around api rate limiting.
 - Add Development, Test and Vendor Sandbox enviroment details to [api info](/reference/#api-info) page.
 - Add [/test-data/regenerate](/reference/#post-test-data-regenerate) endpoint.
 - Add [single application](/reference/#singleapplicationresponse) and [multiple applications](/reference/#multipleapplicationsresponse) response schemas.


### PR DESCRIPTION
### Context

We would like to add some guidance on rate limiting for the vendor api docs to make sure vendors are aware and allow us to more easily add rate limiting in the future.

### Changes proposed in this pull request

![image](https://user-images.githubusercontent.com/47318392/67385902-e30c3c80-f58b-11e9-85b5-3454536034f2.png)

- Add some simple guidance to the tech docs around rate limiting.

### Guidance to review

Read the `Rate Limits` section of the tech docs and check that we are happy with the guidance.

### Release notes

- [x] [If needed](/README.md#release-notes), the [release notes](/source/release-notes.html.md) have been updated

### Link to Trello card

[1114 - Add information about rate limiting to the api](https://trello.com/c/O4CQjIHh/1114-add-information-about-rate-limiting-to-the-api)
