### PR TITLE
Add request body arguemnts to tech docs

### DIFF
--- a/lib/govuk_tech_docs/api_reference/renderer.rb
+++ b/lib/govuk_tech_docs/api_reference/renderer.rb
@@ -10,6 +10,7 @@ module GovukTechDocs
         @template_operation = get_renderer('operation.html.erb')
         @template_parameters = get_renderer('parameters.html.erb')
         @template_responses = get_renderer('responses.html.erb')
+        @template_arguments = get_renderer('arguments.html.erb')
       end
 
       def render_api_reference
@@ -33,6 +34,24 @@ module GovukTechDocs
         end
 
         @template_schema.result(binding)
+      end
+
+      def render_argument_block(schema_name, schema)
+        properties = []
+
+        if schema["allOf"]
+          schema["allOf"].each do |schema_nested|
+            schema_nested.properties.each do |property|
+              properties << property
+            end
+          end
+        end
+
+        schema.properties.each do |property|
+          properties << property
+        end
+
+        @template_arguments.result(binding)
       end
 
       # This method is called by the templates via `binding`

--- a/lib/govuk_tech_docs/api_reference/templates/arguments.html.erb
+++ b/lib/govuk_tech_docs/api_reference/templates/arguments.html.erb
@@ -1,0 +1,41 @@
+<% if properties.any? %>
+### <%= schema_name %>
+<table>
+<thead>
+  <tr>
+    <th>Name</th>
+    <th>Type</th>
+    <th>Required</th>
+    <th>Description</th>
+    <th>Schema</th>
+  </tr>
+</thead>
+<tbody>
+<% properties.each do |property_name, property_attributes| %>
+<tr>
+  <td><%= property_name %></td>
+  <td><%= property_attributes.type %></td>
+  <td><%= property_name.in?(schema.required.to_a) ? "true" : "false" %></td>
+  <td>
+    <%= property_attributes.description %>
+    <% if property_attributes.type == 'string' && property_attributes.max_length.present? %>
+      <p>(limited to <%= property_attributes.max_length %> characters)</p>
+    <% elsif property_attributes.type == 'array' && property_attributes.max_items.present? %>
+      <p>(limited to <%= property_attributes.max_items %> elements)</p>
+    <% end %>
+  </td>
+  <td>
+    <%=
+    linked_schema = property_attributes
+    # If property is an array, check the items property for a reference.
+    if property_attributes.type == 'array'
+      linked_schema = property_attributes['items']
+    end
+    # Only print a link if it's a referenced object.
+    get_schema_link(linked_schema) if linked_schema.node_context.referenced_by.to_s.include?('#/components/schemas') && !linked_schema.node_context.source_location.to_s.include?('/properties/') %>
+  </td>
+</tr>
+<% end %>
+</tbody>
+</table>
+<% end %>

--- a/lib/govuk_tech_docs/api_reference/templates/operation.html.erb
+++ b/lib/govuk_tech_docs/api_reference/templates/operation.html.erb
@@ -21,13 +21,10 @@
 
   <pre><code><%= example %></code></pre>
 
-### Arguments
+### Request body schema
  <% operation.request_body.content['application/json'].schema.properties.each do |prop_name, prop| %>
         <%= render_argument_block(prop_name, prop) %>
-        <% puts "Argument name: #{prop_name}" %>
         <% prop.properties.each do |property_name, property| %>
-          <% puts "Property name: #{property_name}" %>
-          <% puts property.properties if  prop_name == 'meta' %>
           <%= render_argument_block(property_name, property) %>
         <% end %>
       <% end %>

--- a/lib/govuk_tech_docs/api_reference/templates/operation.html.erb
+++ b/lib/govuk_tech_docs/api_reference/templates/operation.html.erb
@@ -18,7 +18,19 @@
      example = render_schema_example_as_json_block(operation.request_body.content['application/json'].schema)
    end
  end %>
- <pre><code><%= example %></code></pre>
+
+  <pre><code><%= example %></code></pre>
+
+### Arguments
+ <% operation.request_body.content['application/json'].schema.properties.each do |prop_name, prop| %>
+        <%= render_argument_block(prop_name, prop) %>
+        <% puts "Argument name: #{prop_name}" %>
+        <% prop.properties.each do |property_name, property| %>
+          <% puts "Property name: #{property_name}" %>
+          <% puts property.properties if  prop_name == 'meta' %>
+          <%= render_argument_block(property_name, property) %>
+        <% end %>
+      <% end %>
 <% end %>
 
 <%= responses_html %>

--- a/source/release-notes.html.md
+++ b/source/release-notes.html.md
@@ -5,6 +5,10 @@ weight: 200
 
 # Release notes
 
+### Unreleased
+
+- Update tech docs to display request body schema details. 
+
 ### Release 0.8.0 - 29 October 2019
 
 Changes to the data:


### PR DESCRIPTION
### Context

The "Request body" part of the template doesn't show what to send in the request body, only an example.

### Changes proposed in this pull request

Add an arguments temple and renderer function to display request_body argument details.

### Guidance to review

![image](https://user-images.githubusercontent.com/47318392/68022985-d7acc580-fc9d-11e9-8b35-9432610aa064.png)

Check argument rendering function and temple to check that the correct information is displayed.
### Release notes

- [ ] [If needed](/README.md#release-notes), the [release notes](/source/release-notes.html.md) have been updated

### Link to Trello card

[1118 - Add request body schema to endpoints](https://trello.com/c/uyXUmycj/1118-add-request-body-schema-to-endpoints)
