### PR TITLE
Update reject_application in tech-docs to use rejections schema

### DIFF
--- a/source/openapi-spec.yml
+++ b/source/openapi-spec.yml
@@ -628,18 +628,12 @@ components:
       additionalProperties: false
       required:
         - reason
-        - date
       properties:
         reason:
           type: string
           description: The reason for rejection
           maxLength: 255
           example: Does not meet minimum GCSE requirements
-        date:
-          type: string
-          format: date-time
-          description: The date on which the rejection was issued
-          example: "2019-09-18T15:33:49.216Z"
     Withdrawal:
       type: object
       additionalProperties: false

--- a/source/openapi-spec.yml
+++ b/source/openapi-spec.yml
@@ -168,11 +168,7 @@ paths:
               type: object
               properties:
                 data:
-                  type: object
-                  properties:
-                    reason:
-                      type: string
-                      example: Does not meet minimum GCSE requirements
+                  $ref: '#/components/schemas/Rejection'
                 meta:
                   $ref: '#/components/schemas/TimestampAndAttribution'
       responses:

--- a/source/release-notes.html.md
+++ b/source/release-notes.html.md
@@ -7,7 +7,10 @@ weight: 200
 
 ### Unreleased
 
-- Update tech docs to display request body schema details. 
+- Update tech docs to display request body schema details.
+
+Changes to data:
+- Remove date from Rejection schema
 
 ### Release 0.8.0 - 29 October 2019
 


### PR DESCRIPTION
### Context

The reject application endpoint is not using the rejection schema in the tech-docs yml
### Changes proposed in this pull request

### Guidance to review

Check the docs to ensure the correct information is being displayed for rejecting applications.

This is linked to the PR here: https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/429

### Release notes

- [x] [If needed](/README.md#release-notes), the [release notes](/source/release-notes.html.md) have been updated

### Link to Trello card
