### PR TITLE
Update tech docs to include state declined

### DIFF
--- a/source/openapi-spec.yml
+++ b/source/openapi-spec.yml
@@ -309,6 +309,7 @@ components:
             - recruited
             - enrolled
             - rejected
+            - declined
           example: application_complete
         submitted_at:
           type: string

--- a/source/openapi-spec.yml
+++ b/source/openapi-spec.yml
@@ -301,15 +301,14 @@ components:
           type: string
           description: The status of this application
           enum:
-            - unsubmitted
-            - application_complete
-            - conditional_offer
-            - unconditional_offer
-            - meeting_conditions
+            - awaiting_provider_decision
+            - offer
+            - pending_conditions
             - recruited
             - enrolled
             - rejected
             - declined
+            - withdrawn
           example: application_complete
         submitted_at:
           type: string

--- a/source/release-notes.html.md
+++ b/source/release-notes.html.md
@@ -11,6 +11,14 @@ weight: 200
 
 Changes to data:
 - Remove date from Rejection schema
+- Add `declined` status for application
+- Add `offer` status for application
+- Remove `conditional_offer` and `unconditional_offer` statuses from application
+- Add `awaiting_provider_decision` status for application
+- Add `pending_conditions` status for application
+- Remove `meeting_conditions` status from application
+- Add `withdrawn` status to application
+- Remove `unsubmitted` and `application_complete` statuses from application
 
 ### Release 0.8.0 - 29 October 2019
 


### PR DESCRIPTION
### Context

The `declined` status was previously removed from applications in error. 
This PR adds it back.

### Changes proposed in this pull request
Add `declined` status back for ApplicationAttributes status enum.

### Guidance to review

### Release notes

- [x] [If needed](/README.md#release-notes), the [release notes](/source/release-notes.html.md) have been updated

### Link to Trello card

[1267 - Update tech docs to include state declined](https://trello.com/c/ndSAZAQX/1267-update-tech-docs-to-include-state-declined)
